### PR TITLE
preferences: select default currency

### DIFF
--- a/tuttle_ui/preferences/view/preferences_screen.py
+++ b/tuttle_ui/preferences/view/preferences_screen.py
@@ -87,6 +87,13 @@ class PreferencesScreen(TuttleView, UserControl):
             lbl="Appearance",
             hint="",
         )
+
+        self.currencyControl = get_dropdown(
+            items=["USD ($)", "EUR (€)", "GBP (£)"],
+            onChange=lambda e: None,
+            lbl="Default currency",
+            hint="",
+        )
         self.body = Container(
             padding=padding.all(spacing.SPACE_MD),
             width=int(MIN_WINDOW_WIDTH * 0.7),
@@ -103,6 +110,8 @@ class PreferencesScreen(TuttleView, UserControl):
                     self.loadingIndicator,
                     mdSpace,
                     self.themeControl,
+                    mdSpace,
+                    self.currencyControl,
                 ],
             ),
         )


### PR DESCRIPTION
Tried adding a preferences field for selecting the default currency.


ps: I am confused about the mixture of CamelCase and snake_case. In general the code style for Tuttle should use snake_case. Is there a reason to deviate from that?