### PR TITLE
refactor: prefix custom flet components with T 

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -13,12 +13,12 @@ from flet import (
 
 from auth.view import ProfileScreen, SplashScreen
 from contracts.view import ContractEditorScreen, ViewContractScreen
-from core.abstractions import TuttleView, TuttleViewParams
+from core.abstractions import TView, TViewParams
 from core.client_storage_impl import ClientStorageImpl
 from core.database_storage_impl import DatabaseStorageImpl
 from core.models import RouteView
 from core.utils import AlertDialogControls
-from core.views import StdHeading
+from core.views import THeading
 from error_views.page_not_found_screen import Error404Screen
 from home.view import HomeScreen
 from loguru import logger
@@ -149,7 +149,7 @@ class TuttleApp:
             self.page.snack_bar.open = False
             self.page.update()
         self.page.snack_bar = SnackBar(
-            StdHeading(
+            THeading(
                 title=message,
                 size=HEADLINE_4_SIZE,
                 color=ERROR_COLOR if is_error else WHITE_COLOR,
@@ -197,8 +197,8 @@ class TuttleApp:
         self.page.go(current_page_view.route)
         if current_page_view.controls:
             try:
-                # the controls should contain a TuttleView as first control
-                tuttle_view: TuttleView = current_page_view.controls[0]
+                # the controls should contain a TView as first control
+                tuttle_view: TView = current_page_view.controls[0]
                 # notify view that it has been resumed
                 tuttle_view.on_resume_after_back_pressed()
             except Exception as e:
@@ -268,7 +268,7 @@ class TuttleRoutes:
         self.on_reset_and_quit = app.reset_and_quit
         self.on_install_demo_data = app.db.install_demo_data
         # init common params for views
-        self.tuttle_view_params = TuttleViewParams(
+        self.tuttle_view_params = TViewParams(
             navigate_to_route=app.change_route,
             show_snack=app.show_snack,
             dialog_controller=app.control_alert_dialog,
@@ -281,7 +281,7 @@ class TuttleRoutes:
     def get_page_route_view(
         self,
         routeName: str,
-        view: TuttleView,
+        view: TView,
     ) -> RouteView:
         """Constructs the view with a given route"""
         view_container = View(

--- a/app/auth/view.py
+++ b/app/auth/view.py
@@ -17,7 +17,7 @@ from flet import (
 
 from auth.intent import AuthIntent
 from core import utils, views
-from core.abstractions import TuttleView, TuttleViewParams
+from core.abstractions import TView, TViewParams
 from core.intent_result import IntentResult
 from res import dimens, fonts, image_paths, res_utils, colors, theme
 from preferences.intent import PreferencesIntent
@@ -75,22 +75,22 @@ class PaymentDataForm(UserControl):
 
     def build(self):
         """Called when form is built"""
-        self.vat_number_field = views.StdTextField(
+        self.vat_number_field = views.TTextField(
             on_change=self.on_vat_number_changed,
             label="VAT Number",
             hint="Value Added Tax number of the user, legally required for invoices.",
         )
-        self.bank_name_field = views.StdTextField(
+        self.bank_name_field = views.TTextField(
             on_change=self.on_bank_name_changed,
             label="Name",
             hint="Name of account",
         )
-        self.bank_iban_field = views.StdTextField(
+        self.bank_iban_field = views.TTextField(
             on_change=self.on_bank_iban_changed,
             label="IBAN",
             hint="International Bank Account Number",
         )
-        self.bank_ibc_field = views.StdTextField(
+        self.bank_ibc_field = views.TTextField(
             on_change=self.on_bank_bic_changed,
             label="BIC",
             hint="Bank Identifier Code",
@@ -100,12 +100,12 @@ class PaymentDataForm(UserControl):
             controls=[
                 self.vat_number_field,
                 views.Spacer(xs_space=True),
-                views.StdSubHeading("Bank Account"),
+                views.TSubHeading("Bank Account"),
                 self.bank_name_field,
                 self.bank_iban_field,
                 self.bank_ibc_field,
                 views.Spacer(),
-                views.StdPrimaryButton(
+                views.TPrimaryButton(
                     label="Save",
                     on_click=lambda e: self.on_form_submit(self.user),
                 ),
@@ -225,71 +225,71 @@ class UserDataForm(UserControl):
 
     def build(self):
         """Called when form is built"""
-        self.name_field = views.StdTextField(
+        self.name_field = views.TTextField(
             lambda e: self.on_field_value_changed("name", e),
             "Name",
             "your name",
             on_focus=self.on_field_focus,
             keyboard_type=utils.KEYBOARD_NAME,
         )
-        self.email_field = views.StdTextField(
+        self.email_field = views.TTextField(
             lambda e: self.on_field_value_changed("email", e),
             "Email",
             "your email address",
             on_focus=self.on_field_focus,
             keyboard_type=utils.KEYBOARD_EMAIL,
         )
-        self.phone_field = views.StdTextField(
+        self.phone_field = views.TTextField(
             lambda e: self.on_field_value_changed("phone", e),
             "Phone (optional)",
             "your phone number",
             on_focus=self.on_field_focus,
             keyboard_type=utils.KEYBOARD_PHONE,
         )
-        self.title_field = views.StdTextField(
+        self.title_field = views.TTextField(
             lambda e: self.on_field_value_changed("title", e),
             "Job Title",
             "What is your role as a freelancer?",
             on_focus=self.on_field_focus,
             keyboard_type=utils.KEYBOARD_TEXT,
         )
-        self.website_field = views.StdTextField(
+        self.website_field = views.TTextField(
             lambda e: self.on_field_value_changed("website", e),
             "Website (optional)",
             "URL of your website.",
         )
-        self.street_field = views.StdTextField(
+        self.street_field = views.TTextField(
             lambda e: self.on_field_value_changed("street", e),
             label="Street Name",
             keyboard_type=utils.KEYBOARD_TEXT,
             expand=1,
         )
-        self.street_number_field = views.StdTextField(
+        self.street_number_field = views.TTextField(
             lambda e: self.on_field_value_changed("street_number", e),
             label="Street Number",
             keyboard_type=utils.KEYBOARD_NUMBER,
             expand=1,
         )
-        self.postal_code_field = views.StdTextField(
+        self.postal_code_field = views.TTextField(
             lambda e: self.on_field_value_changed("postal_code", e),
             label="Postal Code",
             keyboard_type=utils.KEYBOARD_NUMBER,
             expand=1,
         )
 
-        self.city_field = views.StdTextField(
+        self.city_field = views.TTextField(
             lambda e: self.on_field_value_changed("city", e),
             label="City",
             keyboard_type=utils.KEYBOARD_TEXT,
             expand=1,
         )
-        self.country_field = views.StdTextField(
+        self.country_field = views.TTextField(
             lambda e: self.on_field_value_changed("country", e),
             label="Country",
             keyboard_type=utils.KEYBOARD_TEXT,
         )
-        self.form_err_control = views.StdErrorText("")
-        self.submit_btn = views.StdPrimaryButton(
+        self.form_err_control = views.TErrorText("")
+        self.submit_btn = views.TPrimaryButton(
             on_click=self.on_submit_btn_clicked,
             label=self.submit_btn_label,
         )
@@ -337,7 +337,7 @@ class UserDataForm(UserControl):
         self.update()
 
 
-class SplashScreen(TuttleView, UserControl):
+class SplashScreen(TView, UserControl):
     """Displayed the first time the app loads
 
     Checks if user has been created
@@ -347,7 +347,7 @@ class SplashScreen(TuttleView, UserControl):
 
     def __init__(
         self,
-        params: TuttleViewParams,
+        params: TViewParams,
         on_install_demo_data: Callable,
     ):
         super().__init__(params=params)
@@ -401,11 +401,11 @@ class SplashScreen(TuttleView, UserControl):
         self.show_login_if_signed_out_else_redirect()
 
     def build(self):
-        self.loading_indicator = views.StdProgressBar()
+        self.loading_indicator = views.TProgressBar()
         self.form_container = Column(
             controls=[
-                # views.StdAppLogoWithLabel(),
-                views.StdHeadingWithSubheading(
+                # views.TAppLogoWithLabel(),
+                views.THeadingWithSubheading(
                     "Welcome to Tuttle",
                     "Let's get you started: Please enter your details below. Your data will be stored locally and will not be sent to a server.",
                 ),
@@ -428,12 +428,12 @@ class SplashScreen(TuttleView, UserControl):
                         expand=True,
                         controls=[
                             views.Spacer(md_space=True),
-                            views.StdImage(
+                            views.TImage(
                                 image_paths.splashImgPath,
                                 "welcome screen image",
                                 width=300,
                             ),
-                            views.StdHeadingWithSubheading(
+                            views.THeadingWithSubheading(
                                 "Tuttle",
                                 "Time and money management for freelancers",
                                 alignment_in_container=utils.CENTER_ALIGNMENT,
@@ -450,7 +450,7 @@ class SplashScreen(TuttleView, UserControl):
                     content=Column(
                         [
                             self.form_container,
-                            views.StdSecondaryButton(
+                            views.TSecondaryButton(
                                 on_click=self.on_proceed_with_demo_data_clicked,
                                 label="Proceed with demo",
                                 icon="TOYS",
@@ -471,7 +471,7 @@ class ProfileMenuItemsHandler:
 
     def __init__(
         self,
-        params: TuttleViewParams,
+        params: TViewParams,
     ):
         super().__init__()
         self.menu_title = "My Profile"
@@ -515,10 +515,10 @@ def profile_destination_content_wrapper(
     )
 
 
-class ProfilePhotoContent(TuttleView, UserControl):
+class ProfilePhotoContent(TView, UserControl):
     """Content for profile photo"""
 
-    def __init__(self, params: TuttleViewParams):
+    def __init__(self, params: TViewParams):
         super().__init__(params)
         self.intent = AuthIntent()
         self.uploaded_photo_path = ""
@@ -564,13 +564,13 @@ class ProfilePhotoContent(TuttleView, UserControl):
             self.update_self()
 
     def build(self):
-        self.profile_photo_img = views.StdProfilePhotoImg()
-        self.update_photo_btn = views.StdSecondaryButton(
+        self.profile_photo_img = views.TProfilePhotoImg()
+        self.update_photo_btn = views.TSecondaryButton(
             label="Update Photo",
             on_click=self.on_update_photo_clicked,
         )
         self.profile_photo_content = [
-            views.StdHeading(
+            views.THeading(
                 "Profile Photo",
                 size=fonts.HEADLINE_4_SIZE,
             ),
@@ -599,10 +599,10 @@ class ProfilePhotoContent(TuttleView, UserControl):
         self.mounted = False
 
 
-class UserInfoContent(TuttleView, UserControl):
+class UserInfoContent(TView, UserControl):
     """Content for user info"""
 
-    def __init__(self, params: TuttleViewParams):
+    def __init__(self, params: TViewParams):
         super().__init__(params)
         self.intent = AuthIntent()
         self.user_profile: User = None
@@ -632,7 +632,7 @@ class UserInfoContent(TuttleView, UserControl):
             submit_btn_label="Save",
         )
         self.user_info_content = [
-            views.StdHeading(
+            views.THeading(
                 "Personal Info",
                 size=fonts.HEADLINE_4_SIZE,
             ),
@@ -658,10 +658,10 @@ class UserInfoContent(TuttleView, UserControl):
         self.mounted = False
 
 
-class PaymentInfoContent(TuttleView, UserControl):
+class PaymentInfoContent(TView, UserControl):
     """Content for payment info"""
 
-    def __init__(self, params: TuttleViewParams):
+    def __init__(self, params: TViewParams):
         super().__init__(params)
         self.intent = AuthIntent()
         self.user_profile: User = None
@@ -681,7 +681,7 @@ class PaymentInfoContent(TuttleView, UserControl):
             on_form_submit=self.on_update_payment_info,
         )
         self.payment_info_content = [
-            views.StdHeading(
+            views.THeading(
                 "Payment Settings",
                 size=fonts.HEADLINE_4_SIZE,
             ),
@@ -707,10 +707,10 @@ class PaymentInfoContent(TuttleView, UserControl):
         self.mounted = False
 
 
-class ProfileScreen(TuttleView, UserControl):
+class ProfileScreen(TView, UserControl):
     """User profile screen"""
 
-    def __init__(self, params: TuttleViewParams):
+    def __init__(self, params: TViewParams):
         super().__init__(params=params)
         self.preferences_intent = PreferencesIntent(
             client_storage=params.client_storage,
@@ -720,7 +720,7 @@ class ProfileScreen(TuttleView, UserControl):
         )
         self.current_menu_index = 0
         # initialize the side bar menu
-        self.side_bar_menu = views.StdNavigationMenu(
+        self.side_bar_menu = views.TNavigationMenu(
             title=self.menu_handler.menu_title,
             destinations=self.get_menu_destinations(),
             on_change=lambda e: self.on_menu_destination_change(e),
@@ -744,7 +744,7 @@ class ProfileScreen(TuttleView, UserControl):
                     item.selected_icon,
                     size=dimens.ICON_SIZE,
                 ),
-                label_content=views.StdBodyText(item.label),
+                label_content=views.TBodyText(item.label),
                 padding=padding.symmetric(horizontal=dimens.SPACE_SM),
             )
             items.append(itemDestination)

--- a/app/clients/view.py
+++ b/app/clients/view.py
@@ -17,7 +17,7 @@ from flet import (
 
 from clients.intent import ClientsIntent
 from core import utils, views
-from core.abstractions import DialogHandler, TuttleView, TuttleViewParams
+from core.abstractions import DialogHandler, TView, TViewParams
 from core.intent_result import IntentResult
 from res import colors, dimens, fonts, res_utils
 
@@ -48,7 +48,7 @@ class ClientCard(UserControl):
         editable = True if self.on_edit_clicked or self.on_delete_clicked else None
 
         editor_controls = (
-            views.StdContextMenu(
+            views.TContextMenu(
                 on_click_delete=lambda e: self.on_delete_clicked(self.client),
                 on_click_edit=lambda e: self.on_edit_clicked(self.client),
             )
@@ -62,19 +62,19 @@ class ClientCard(UserControl):
                     utils.TuttleComponentIcons.client_icon,
                     size=dimens.ICON_SIZE,
                 ),
-                title=views.StdBodyText(self.client.name),
+                title=views.TBodyText(self.client.name),
                 trailing=editor_controls,
             ),
             views.Spacer(md_space=True),
             ResponsiveRow(
                 controls=[
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt="Invoicing Contact",
                         color=colors.GRAY_COLOR,
                         size=fonts.BODY_2_SIZE,
                         col={"xs": "12"},
                     ),
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt=invoicing_contact_info,
                         size=fonts.BODY_2_SIZE,
                         col={"xs": "12"},
@@ -163,73 +163,73 @@ class ClientEditorPopUp(DialogHandler, UserControl):
             self.invoicing_contact.id
         )
 
-        self.first_name_field = views.StdTextField(
+        self.first_name_field = views.TTextField(
             on_change=self.on_fname_changed,
             label="First Name",
             hint=self.invoicing_contact.first_name,
             initial_value=self.invoicing_contact.first_name,
         )
 
-        self.last_name_field = views.StdTextField(
+        self.last_name_field = views.TTextField(
             on_change=self.on_lname_changed,
             label="Last Name",
             hint=self.invoicing_contact.last_name,
             initial_value=self.invoicing_contact.last_name,
         )
-        self.company_field = views.StdTextField(
+        self.company_field = views.TTextField(
             on_change=self.on_company_changed,
             label="Company",
             hint=self.invoicing_contact.company,
             initial_value=self.invoicing_contact.company,
         )
-        self.email_field = views.StdTextField(
+        self.email_field = views.TTextField(
             on_change=self.on_email_changed,
             label="Email",
             hint=self.invoicing_contact.email,
             initial_value=self.invoicing_contact.email,
         )
 
-        self.street_field = views.StdTextField(
+        self.street_field = views.TTextField(
             on_change=self.on_street_changed,
             label="Street",
             hint=self.invoicing_contact.address.street,
             initial_value=self.invoicing_contact.address.street,
             width=half_of_pop_up_width,
         )
-        self.street_num_field = views.StdTextField(
+        self.street_num_field = views.TTextField(
             on_change=self.on_street_num_changed,
             label="Street No.",
             hint=self.invoicing_contact.address.number,
             initial_value=self.invoicing_contact.address.number,
             width=half_of_pop_up_width,
         )
-        self.postal_code_field = views.StdTextField(
+        self.postal_code_field = views.TTextField(
             on_change=self.on_postal_code_changed,
             label="Postal code",
             hint=self.invoicing_contact.address.postal_code,
             initial_value=self.invoicing_contact.address.postal_code,
             width=half_of_pop_up_width,
         )
-        self.city_field = views.StdTextField(
+        self.city_field = views.TTextField(
             on_change=self.on_city_changed,
             label="City",
             hint=self.invoicing_contact.address.city,
             initial_value=self.invoicing_contact.address.city,
             width=half_of_pop_up_width,
         )
-        self.country_field = views.StdTextField(
+        self.country_field = views.TTextField(
             on_change=self.on_country_changed,
             label="Country",
             hint=self.invoicing_contact.address.country,
             initial_value=self.invoicing_contact.address.country,
         )
-        self.contacts_dropdown = views.StdDropDown(
+        self.contacts_dropdown = views.TDropDown(
             on_change=self.on_contact_selected,
             label="Select contact",
             items=self.contact_options,
             initial_value=initial_selected_contact,
         )
-        self.form_error_field = views.StdErrorText(txt="", show=False)
+        self.form_error_field = views.TErrorText(txt="", show=False)
 
         dialog = AlertDialog(
             content=Container(
@@ -237,18 +237,18 @@ class ClientEditorPopUp(DialogHandler, UserControl):
                 content=Column(
                     scroll=utils.AUTO_SCROLL,
                     controls=[
-                        views.StdHeading(title=title, size=fonts.HEADLINE_4_SIZE),
+                        views.THeading(title=title, size=fonts.HEADLINE_4_SIZE),
                         views.Spacer(xs_space=True),
                         self.form_error_field,
                         views.Spacer(xs_space=True),
-                        views.StdTextField(
+                        views.TTextField(
                             on_change=self.on_client_name_changed,
                             label="Client's name",
                             hint=self.client.name,
                             initial_value=self.client.name,
                         ),
                         views.Spacer(xs_space=True),
-                        views.StdHeading(
+                        views.THeading(
                             title="Invoicing Contact",
                             size=fonts.SUBTITLE_2_SIZE,
                             color=colors.GRAY_COLOR,
@@ -278,9 +278,7 @@ class ClientEditorPopUp(DialogHandler, UserControl):
                 width=pop_up_width,
             ),
             actions=[
-                views.StdPrimaryButton(
-                    label="Done", on_click=self.on_submit_btn_clicked
-                ),
+                views.TPrimaryButton(label="Done", on_click=self.on_submit_btn_clicked),
             ],
         )
         super().__init__(dialog=dialog, dialog_controller=dialog_controller)
@@ -463,14 +461,14 @@ class ClientEditorPopUp(DialogHandler, UserControl):
         return self.dialog
 
 
-class ClientsListView(TuttleView, UserControl):
+class ClientsListView(TView, UserControl):
     """View for displaying a list of clients"""
 
-    def __init__(self, params: TuttleViewParams):
+    def __init__(self, params: TViewParams):
         super().__init__(params=params)
         self.intent = ClientsIntent()
-        self.loading_indicator = views.StdProgressBar()
-        self.no_clients_control = views.StdBodyText(
+        self.loading_indicator = views.TProgressBar()
+        self.no_clients_control = views.TBodyText(
             txt="You have not added any clients yet.",
             color=colors.ERROR_COLOR,
             show=False,
@@ -480,9 +478,7 @@ class ClientsListView(TuttleView, UserControl):
                 Column(
                     col={"xs": 12},
                     controls=[
-                        views.StdHeading(
-                            title="My Clients", size=fonts.HEADLINE_4_SIZE
-                        ),
+                        views.THeading(title="My Clients", size=fonts.HEADLINE_4_SIZE),
                         self.loading_indicator,
                         self.no_clients_control,
                     ],

--- a/app/contacts/view.py
+++ b/app/contacts/view.py
@@ -17,7 +17,7 @@ from flet import (
 
 from contacts.intent import ContactsIntent
 from core import utils, views
-from core.abstractions import DialogHandler, TuttleView, TuttleViewParams
+from core.abstractions import DialogHandler, TView, TViewParams
 from core.intent_result import IntentResult
 from res import colors, dimens, fonts, res_utils
 
@@ -50,11 +50,11 @@ class ContactCard(UserControl):
                     utils.TuttleComponentIcons.contact_icon,
                     size=dimens.ICON_SIZE,
                 ),
-                title=views.StdBodyText(utils.truncate_str(self.contact.name)),
-                subtitle=views.StdBodyText(
+                title=views.TBodyText(utils.truncate_str(self.contact.name)),
+                subtitle=views.TBodyText(
                     utils.truncate_str(self.contact.company), color=colors.GRAY_COLOR
                 ),
-                trailing=views.StdContextMenu(
+                trailing=views.TContextMenu(
                     on_click_edit=lambda e: self.on_edit_clicked(self.contact),
                     on_click_delete=lambda e: self.on_deleted_clicked(self.contact),
                 ),
@@ -62,13 +62,13 @@ class ContactCard(UserControl):
             views.Spacer(md_space=True),
             ResponsiveRow(
                 controls=[
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt="email",
                         color=colors.GRAY_COLOR,
                         size=fonts.BODY_2_SIZE,
                         col={"xs": "12"},
                     ),
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt=self.contact.email,
                         size=fonts.BODY_2_SIZE,
                         col={"xs": "12"},
@@ -81,14 +81,14 @@ class ContactCard(UserControl):
             views.Spacer(md_space=True),
             ResponsiveRow(
                 controls=[
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt="address",
                         color=colors.GRAY_COLOR,
                         size=fonts.BODY_2_SIZE,
                         col={"xs": "12"},
                     ),
                     Container(
-                        views.StdBodyText(
+                        views.TBodyText(
                             txt=self.contact.print_address(address_only=True).strip(),
                             size=fonts.BODY_2_SIZE,
                             col={"xs": "12"},
@@ -142,27 +142,27 @@ class ContactEditorPopUp(DialogHandler):
                 content=Column(
                     scroll=utils.AUTO_SCROLL,
                     controls=[
-                        views.StdHeading(title=title, size=fonts.HEADLINE_4_SIZE),
+                        views.THeading(title=title, size=fonts.HEADLINE_4_SIZE),
                         views.Spacer(xs_space=True),
-                        views.StdTextField(
+                        views.TTextField(
                             on_change=self.on_fname_changed,
                             label="First Name",
                             hint=self.contact.first_name,
                             initial_value=self.contact.first_name,
                         ),
-                        views.StdTextField(
+                        views.TTextField(
                             on_change=self.on_lname_changed,
                             label="Last Name",
                             hint=self.contact.last_name,
                             initial_value=self.contact.last_name,
                         ),
-                        views.StdTextField(
+                        views.TTextField(
                             on_change=self.on_company_changed,
                             label="Company",
                             hint=self.contact.company,
                             initial_value=self.contact.company,
                         ),
-                        views.StdTextField(
+                        views.TTextField(
                             on_change=self.on_email_changed,
                             label="Email",
                             hint=self.contact.email,
@@ -171,14 +171,14 @@ class ContactEditorPopUp(DialogHandler):
                         Row(
                             vertical_alignment=utils.CENTER_ALIGNMENT,
                             controls=[
-                                views.StdTextField(
+                                views.TTextField(
                                     on_change=self.on_street_changed,
                                     label="Street",
                                     hint=self.contact.address.street,
                                     initial_value=self.contact.address.street,
                                     width=width_spanning_half_of_container,
                                 ),
-                                views.StdTextField(
+                                views.TTextField(
                                     on_change=self.on_street_num_changed,
                                     label="Street No.",
                                     hint=self.contact.address.number,
@@ -190,14 +190,14 @@ class ContactEditorPopUp(DialogHandler):
                         Row(
                             vertical_alignment=utils.CENTER_ALIGNMENT,
                             controls=[
-                                views.StdTextField(
+                                views.TTextField(
                                     on_change=self.on_postal_code_changed,
                                     label="Postal code",
                                     hint=self.contact.address.postal_code,
                                     initial_value=self.contact.address.postal_code,
                                     width=width_spanning_half_of_container,
                                 ),
-                                views.StdTextField(
+                                views.TTextField(
                                     on_change=self.on_city_changed,
                                     label="City",
                                     hint=self.contact.address.city,
@@ -206,7 +206,7 @@ class ContactEditorPopUp(DialogHandler):
                                 ),
                             ],
                         ),
-                        views.StdTextField(
+                        views.TTextField(
                             on_change=self.on_country_changed,
                             label="Country",
                             hint=self.contact.address.country,
@@ -218,9 +218,7 @@ class ContactEditorPopUp(DialogHandler):
                 width=pop_up_width,
             ),
             actions=[
-                views.StdPrimaryButton(
-                    label="Done", on_click=self.on_submit_btn_clicked
-                ),
+                views.TPrimaryButton(label="Done", on_click=self.on_submit_btn_clicked),
             ],
         )
         super().__init__(dialog=dialog, dialog_controller=dialog_controller)
@@ -320,14 +318,14 @@ class ContactEditorPopUp(DialogHandler):
         self.on_submit_callback(self.contact)
 
 
-class ContactsListView(TuttleView, UserControl):
+class ContactsListView(TView, UserControl):
     """The view for the contacts list page"""
 
-    def __init__(self, params: TuttleViewParams):
+    def __init__(self, params: TViewParams):
         super().__init__(params)
         self.intent = ContactsIntent()
-        self.loading_indicator = views.StdProgressBar()
-        self.no_contacts_control = views.StdBodyText(
+        self.loading_indicator = views.TProgressBar()
+        self.no_contacts_control = views.TBodyText(
             txt="You have not added any contacts yet",
             color=colors.ERROR_COLOR,
             show=False,
@@ -337,9 +335,7 @@ class ContactsListView(TuttleView, UserControl):
                 Column(
                     col={"xs": 12},
                     controls=[
-                        views.StdHeading(
-                            title="My Contacts", size=fonts.HEADLINE_4_SIZE
-                        ),
+                        views.THeading(title="My Contacts", size=fonts.HEADLINE_4_SIZE),
                         self.loading_indicator,
                         self.no_contacts_control,
                     ],

--- a/app/contracts/view.py
+++ b/app/contracts/view.py
@@ -25,7 +25,7 @@ from flet import (
 from clients.view import ClientEditorPopUp, ClientViewPopUp
 from contracts.intent import ContractsIntent
 from core import utils, views
-from core.abstractions import DialogHandler, TuttleView, TuttleViewParams
+from core.abstractions import DialogHandler, TView, TViewParams
 from core.intent_result import IntentResult
 from core.models import (
     get_cycle_from_value,
@@ -62,12 +62,12 @@ class ContractCard(UserControl):
                     utils.TuttleComponentIcons.contract_icon,
                     size=dimens.ICON_SIZE,
                 ),
-                title=views.StdBodyText(self.contract.title),
-                subtitle=views.StdBodyText(
+                title=views.TBodyText(self.contract.title),
+                subtitle=views.TBodyText(
                     self.contract.client.name if self.contract.client else "Unknown",
                     color=colors.GRAY_COLOR,
                 ),
-                trailing=views.StdContextMenu(
+                trailing=views.TContextMenu(
                     on_click_view=lambda e: self.on_click_view(self.contract.id),
                     on_click_edit=lambda e: self.on_click_edit(self.contract.id),
                     on_click_delete=lambda e: self.on_click_delete(self.contract.id),
@@ -77,13 +77,13 @@ class ContractCard(UserControl):
             views.Spacer(md_space=True),
             ResponsiveRow(
                 controls=[
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt="Rate",
                         color=colors.GRAY_COLOR,
                         size=fonts.BODY_2_SIZE,
                         col={"xs": "12"},
                     ),
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt=f"{self.contract.rate} {self.contract.currency} / {self.contract.unit}",
                         size=fonts.BODY_2_SIZE,
                         col={"xs": "12"},
@@ -95,13 +95,13 @@ class ContractCard(UserControl):
             ),
             ResponsiveRow(
                 controls=[
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt="Billing Cycle",
                         color=colors.GRAY_COLOR,
                         size=fonts.BODY_2_SIZE,
                         col={"xs": "12"},
                     ),
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt=f"{self.contract.billing_cycle}",
                         size=fonts.BODY_2_SIZE,
                         col={"xs": "12"},
@@ -114,13 +114,13 @@ class ContractCard(UserControl):
             # add responsive row for contract volume
             ResponsiveRow(
                 controls=[
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt="Volume",
                         color=colors.GRAY_COLOR,
                         size=fonts.BODY_2_SIZE,
                         col={"xs": "12"},
                     ),
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt=f"{self.contract.volume} {self.contract.unit}s",
                         size=fonts.BODY_2_SIZE,
                         col={"xs": "12"},
@@ -244,18 +244,18 @@ class ContractFiltersView(UserControl):
         return self.filters
 
 
-class ContractEditorScreen(TuttleView, UserControl):
+class ContractEditorScreen(TView, UserControl):
     """Used to edit or create a contract"""
 
     def __init__(
-        self, params: TuttleViewParams, contract_id_if_editing: Optional[str] = False
+        self, params: TViewParams, contract_id_if_editing: Optional[str] = False
     ):
         super().__init__(params=params)
         self.horizontal_alignment_in_parent = utils.CENTER_ALIGNMENT
         self.intent = ContractsIntent()
         self.contract_id_if_editing: Optional[str] = contract_id_if_editing
         self.old_contract_if_editing: Optional[Contract] = None
-        self.loading_indicator = views.StdProgressBar()
+        self.loading_indicator = views.TProgressBar()
         self.new_client_pop_up: Optional[DialogHandler] = None
 
         # info of contract being edited / created
@@ -547,64 +547,64 @@ class ContractEditorScreen(TuttleView, UserControl):
 
     def build(self):
         """Build the UI"""
-        self.title_ui_field = views.StdTextField(
+        self.title_ui_field = views.TTextField(
             label="Title",
             hint="Short description of the contract.",
             on_change=self.on_title_changed,
             on_focus=self.clear_ui_field_errors,
         )
-        self.rate_ui_field = views.StdTextField(
+        self.rate_ui_field = views.TTextField(
             label="Rate",
             hint="Rate of remuneration",
             on_change=self.on_rate_changed,
             on_focus=self.clear_ui_field_errors,
             keyboard_type=utils.KEYBOARD_NUMBER,
         )
-        self.currency_ui_field = views.StdDropDown(
+        self.currency_ui_field = views.TDropDown(
             label="Currency",
             hint="Payment currency",
             on_change=self.on_currency_changed,
             items=self.available_currencies,
         )
-        self.vat_rate_ui_field = views.StdTextField(
+        self.vat_rate_ui_field = views.TTextField(
             label="VAT rate",
             hint=f"VAT rate applied to the contractual rate. default is {CONTRACT_DEFAULT_VAT_RATE}",
             on_change=self.on_vat_rate_changed,
             on_focus=self.clear_ui_field_errors,
             keyboard_type=utils.KEYBOARD_NUMBER,
         )
-        self.unit_PW_ui_field = views.StdTextField(
+        self.unit_PW_ui_field = views.TTextField(
             label="Units per workday",
             hint="How many units (e.g. hours) constitute a whole work day?",
             on_change=self.on_upw_changed,
             on_focus=self.clear_ui_field_errors,
             keyboard_type=utils.KEYBOARD_NUMBER,
         )
-        self.volume_ui_field = views.StdTextField(
+        self.volume_ui_field = views.TTextField(
             label="Volume (optional)",
             hint="Number of time units agreed on",
             on_change=self.on_volume_changed,
             on_focus=self.clear_ui_field_errors,
             keyboard_type=utils.KEYBOARD_NUMBER,
         )
-        self.term_of_payment_ui_field = views.StdTextField(
+        self.term_of_payment_ui_field = views.TTextField(
             label="Term of payment (optional)",
             hint="How many days after receipt of invoice this invoice is due.",
             on_change=self.on_term_of_payment_changed,
             on_focus=self.clear_ui_field_errors,
             keyboard_type=utils.KEYBOARD_NUMBER,
         )
-        self.clients_ui_field = views.StdDropDown(
+        self.clients_ui_field = views.TDropDown(
             label="Client",
             on_change=self.on_client_selected,
             items=self.get_clients_names_as_list(),
         )
-        self.units_ui_field = views.StdDropDown(
+        self.units_ui_field = views.TDropDown(
             label="Unit of time tracked.",
             on_change=self.on_unit_selected,
             items=get_time_unit_values_as_list(),
         )
-        self.billing_cycle_ui_field = views.StdDropDown(
+        self.billing_cycle_ui_field = views.TDropDown(
             label="Billing Cycle",
             on_change=self.on_billing_cycle_selected,
             items=get_cycle_values_as_list(),
@@ -612,10 +612,10 @@ class ContractEditorScreen(TuttleView, UserControl):
         self.signature_date_ui_field = views.DateSelector(label="Signed on")
         self.start_date_ui_field = views.DateSelector(label="Valid from")
         self.end_date_ui_field = views.DateSelector(label="Valid until")
-        self.submit_btn = views.StdPrimaryButton(
+        self.submit_btn = views.TPrimaryButton(
             label="Create Contract", on_click=self.on_save
         )
-        self.form_title_ui_field = views.StdHeading(
+        self.form_title_ui_field = views.THeading(
             title="New Contract",
         )
         view = Container(
@@ -689,14 +689,14 @@ class ContractEditorScreen(TuttleView, UserControl):
             self.new_client_pop_up.dimiss_open_dialogs()
 
 
-class ContractsListView(TuttleView, UserControl):
+class ContractsListView(TView, UserControl):
     """View for displaying a list of contracts."""
 
-    def __init__(self, params: TuttleViewParams):
+    def __init__(self, params: TViewParams):
         super().__init__(params)
         self.intent = ContractsIntent()
-        self.loading_indicator = views.StdProgressBar()
-        self.no_contracts_control = views.StdBodyText(
+        self.loading_indicator = views.TProgressBar()
+        self.no_contracts_control = views.TBodyText(
             txt="You have not added any contracts yet",
             color=colors.ERROR_COLOR,
             show=False,
@@ -706,7 +706,7 @@ class ContractsListView(TuttleView, UserControl):
                 Column(
                     col={"xs": 12},
                     controls=[
-                        views.StdHeading(
+                        views.THeading(
                             title="My Contracts", size=fonts.HEADLINE_4_SIZE
                         ),
                         self.loading_indicator,
@@ -842,18 +842,18 @@ class ContractsListView(TuttleView, UserControl):
             self.pop_up_handler.dimiss_open_dialogs()
 
 
-class ViewContractScreen(TuttleView, UserControl):
+class ViewContractScreen(TView, UserControl):
     """Screen to view the details of a contract."""
 
     def __init__(
         self,
-        params: TuttleViewParams,
+        params: TViewParams,
         contract_id: str,
     ):
         super().__init__(params)
         self.intent = ContractsIntent()
         self.contract_id = contract_id
-        self.loading_indicator = views.StdProgressBar()
+        self.loading_indicator = views.TProgressBar()
         self.contract: Optional[Contract] = None
         self.pop_up_handler = None
 
@@ -973,7 +973,7 @@ class ViewContractScreen(TuttleView, UserControl):
         """Returns a row with a label and a control."""
         return ResponsiveRow(
             controls=[
-                views.StdBodyText(
+                views.TBodyText(
                     txt=label,
                     color=colors.GRAY_COLOR,
                     size=fonts.BODY_2_SIZE,
@@ -1011,44 +1011,44 @@ class ViewContractScreen(TuttleView, UserControl):
             icon_size=dimens.ICON_SIZE,
         )
 
-        self.client_control = views.StdHeading()
-        self.contract_title_control = views.StdHeading()
-        self.billing_cycle_control = views.StdBodyText(
+        self.client_control = views.THeading()
+        self.contract_title_control = views.THeading()
+        self.billing_cycle_control = views.TBodyText(
             align=utils.TXT_ALIGN_JUSTIFY,
         )
-        self.rate_control = views.StdBodyText(
+        self.rate_control = views.TBodyText(
             align=utils.TXT_ALIGN_JUSTIFY,
         )
-        self.currency_control = views.StdBodyText(
+        self.currency_control = views.TBodyText(
             align=utils.TXT_ALIGN_JUSTIFY,
         )
-        self.vat_rate_control = views.StdBodyText(
+        self.vat_rate_control = views.TBodyText(
             align=utils.TXT_ALIGN_JUSTIFY,
         )
-        self.unit_control = views.StdBodyText(
+        self.unit_control = views.TBodyText(
             align=utils.TXT_ALIGN_JUSTIFY,
         )
-        self.units_per_workday_control = views.StdBodyText(
+        self.units_per_workday_control = views.TBodyText(
             align=utils.TXT_ALIGN_JUSTIFY,
         )
-        self.volume_control = views.StdBodyText(
+        self.volume_control = views.TBodyText(
             align=utils.TXT_ALIGN_JUSTIFY,
         )
-        self.term_of_payment_control = views.StdBodyText(
-            align=utils.TXT_ALIGN_JUSTIFY,
-        )
-
-        self.signature_date_control = views.StdBodyText(
-            align=utils.TXT_ALIGN_JUSTIFY,
-        )
-        self.start_date_control = views.StdBodyText(
-            align=utils.TXT_ALIGN_JUSTIFY,
-        )
-        self.end_date_control = views.StdBodyText(
+        self.term_of_payment_control = views.TBodyText(
             align=utils.TXT_ALIGN_JUSTIFY,
         )
 
-        self.status_control = views.StdBodyText(
+        self.signature_date_control = views.TBodyText(
+            align=utils.TXT_ALIGN_JUSTIFY,
+        )
+        self.start_date_control = views.TBodyText(
+            align=utils.TXT_ALIGN_JUSTIFY,
+        )
+        self.end_date_control = views.TBodyText(
+            align=utils.TXT_ALIGN_JUSTIFY,
+        )
+
+        self.status_control = views.TBodyText(
             size=fonts.BUTTON_SIZE,
             color=colors.PRIMARY_COLOR,
         )
@@ -1094,7 +1094,7 @@ class ViewContractScreen(TuttleView, UserControl):
                                                 vertical_alignment=utils.CENTER_ALIGNMENT,
                                                 alignment=utils.SPACE_BETWEEN_ALIGNMENT,
                                                 controls=[
-                                                    views.StdHeading(
+                                                    views.THeading(
                                                         title="Contract",
                                                         size=fonts.HEADLINE_4_SIZE,
                                                         color=colors.PRIMARY_COLOR,

--- a/app/core/abstractions.py
+++ b/app/core/abstractions.py
@@ -88,8 +88,8 @@ class ClientStorage(ABC):
 
 
 @dataclass
-class TuttleViewParams:
-    """Parameters for TuttleViews"""
+class TViewParams:
+    """Parameters for TViews"""
 
     navigate_to_route: Callable
     show_snack: Callable
@@ -104,10 +104,10 @@ class TuttleViewParams:
     page_scroll_type: Optional[str] = AUTO_SCROLL
 
 
-class TuttleView(ABC):
+class TView(ABC):
     """Abstract class for all UI screens"""
 
-    def __init__(self, params: TuttleViewParams):
+    def __init__(self, params: TViewParams):
         super().__init__()
         self.navigate_to_route = params.navigate_to_route
         self.show_snack: Callable[[str, bool], None] = params.show_snack

--- a/app/core/tabular.py
+++ b/app/core/tabular.py
@@ -20,7 +20,7 @@ def data_frame_to_data_table(
 
     # Create a list of DataColumn objects using the column names
     columns = [
-        DataColumn(label=views.StdBodyText(_format_column_name(column_name)))
+        DataColumn(label=views.TBodyText(_format_column_name(column_name)))
         for column_name in column_names
     ]
 
@@ -29,7 +29,7 @@ def data_frame_to_data_table(
     for i, row in data_frame.iterrows():
         # Create a list of DataCell objects for the row
         cells = [
-            DataCell(views.StdBodyText(_format_data_frame_cell_value(value)))
+            DataCell(views.TBodyText(_format_data_frame_cell_value(value)))
             for value in row
         ]
 

--- a/app/core/views.py
+++ b/app/core/views.py
@@ -64,7 +64,7 @@ class Spacer(Container):
         )
 
 
-class StdHeading(Text):
+class THeading(Text):
     """Creates a standard heading"""
 
     def __init__(
@@ -89,7 +89,7 @@ class StdHeading(Text):
         )
 
 
-class StdSubHeading(Text):
+class TSubHeading(Text):
     """Creates a standard subheading"""
 
     def __init__(
@@ -112,7 +112,7 @@ class StdSubHeading(Text):
         )
 
 
-class StdHeadingWithSubheading(Column):
+class THeadingWithSubheading(Column):
     """Creates a standard heading with a subheading"""
 
     def __init__(
@@ -130,12 +130,12 @@ class StdHeadingWithSubheading(Column):
             spacing=0,
             horizontal_alignment=alignment_in_container,
             controls=[
-                StdHeading(
+                THeading(
                     title=title,
                     size=title_size,
                     align=txt_alignment,
                 ),
-                StdSubHeading(
+                TSubHeading(
                     subtitle=subtitle,
                     size=subtitle_size,
                     align=txt_alignment,
@@ -145,7 +145,7 @@ class StdHeadingWithSubheading(Column):
         )
 
 
-class StdBodyText(Text):
+class TBodyText(Text):
     """Creates a standard body text"""
 
     def __init__(
@@ -169,7 +169,7 @@ class StdBodyText(Text):
         )
 
 
-class StdTextField(TextField):
+class TTextField(TextField):
     """Creates a standard text field"""
 
     def __init__(
@@ -208,7 +208,7 @@ class StdTextField(TextField):
         )
 
 
-class StdMultilineField(TextField):
+class TMultilineField(TextField):
     """Creates a standard multiline text field"""
 
     def __init__(
@@ -239,7 +239,7 @@ class StdMultilineField(TextField):
         )
 
 
-class StdErrorText(StdBodyText):
+class TErrorText(TBodyText):
     """Displays text formatted for errors / warnings"""
 
     def __init__(
@@ -250,7 +250,7 @@ class StdErrorText(StdBodyText):
         super().__init__(txt, color=colors.ERROR_COLOR, show=show)
 
 
-class StdPrimaryButton(FilledButton):
+class TPrimaryButton(FilledButton):
     """A button with primary styling"""
 
     def __init__(
@@ -264,7 +264,7 @@ class StdPrimaryButton(FilledButton):
         super().__init__(label, width=width, on_click=on_click, icon=icon, visible=show)
 
 
-class StdSecondaryButton(ElevatedButton):
+class TSecondaryButton(ElevatedButton):
     """A button with secondary styling"""
 
     def __init__(
@@ -283,7 +283,7 @@ class StdSecondaryButton(ElevatedButton):
         )
 
 
-class StdDangerButton(ElevatedButton):
+class TDangerButton(ElevatedButton):
     """A button styled for dangerous actions e.g. delete"""
 
     def __init__(
@@ -306,7 +306,7 @@ class StdDangerButton(ElevatedButton):
         )
 
 
-class StdProfilePhotoImg(Image):
+class TProfilePhotoImg(Image):
     """Creates a profile photo image"""
 
     def __init__(
@@ -322,7 +322,7 @@ class StdProfilePhotoImg(Image):
         )
 
 
-class StdImage(Container):
+class TImage(Container):
     """Creates a standard image wrapped in a container"""
 
     def __init__(
@@ -337,7 +337,7 @@ class StdImage(Container):
         )
 
 
-class StdAppLogo(Container):
+class TAppLogo(Container):
     """Creates a standard app logo"""
 
     def __init__(
@@ -352,15 +352,15 @@ class StdAppLogo(Container):
         )
 
 
-class StdAppLogoWithLabel(Row):
+class TAppLogoWithLabel(Row):
     """Returns app logo with app name next to it"""
 
     def __init__(self):
         super().__init__(
             vertical_alignment=utils.CENTER_ALIGNMENT,
             controls=[
-                StdAppLogo(),
-                StdHeading(
+                TAppLogo(),
+                THeading(
                     "Tuttle",
                     size=fonts.HEADLINE_3_SIZE,
                 ),
@@ -368,7 +368,7 @@ class StdAppLogoWithLabel(Row):
         )
 
 
-class StdProgressBar(ProgressBar):
+class TProgressBar(ProgressBar):
     """Creates a standard progress bar"""
 
     def __init__(
@@ -378,7 +378,7 @@ class StdProgressBar(ProgressBar):
         super().__init__(width=320, height=4, visible=show)
 
 
-class StdDropDown(UserControl):
+class TDropDown(UserControl):
     """Creates a standard dropdown button"""
 
     def __init__(
@@ -465,7 +465,7 @@ class DateSelector(UserControl):
         self.year = str(self.initial_date.year)
         self.label_color = label_color
 
-        self.day_dropdown = StdDropDown(
+        self.day_dropdown = TDropDown(
             label="Day",
             hint="",
             on_change=self.on_date_set,
@@ -474,7 +474,7 @@ class DateSelector(UserControl):
             initial_value=self.date,
         )
 
-        self.month_dropdown = StdDropDown(
+        self.month_dropdown = TDropDown(
             label="Month",
             on_change=self.on_month_set,
             items=[str(month) for month in range(1, 13)],
@@ -482,7 +482,7 @@ class DateSelector(UserControl):
             initial_value=self.month,
         )
 
-        self.year_dropdown = StdDropDown(
+        self.year_dropdown = TDropDown(
             label="Year",
             on_change=self.on_year_set,
             # set items to a list of years -10 to + 10 years from now
@@ -509,7 +509,7 @@ class DateSelector(UserControl):
         self.view = Container(
             content=Column(
                 controls=[
-                    StdBodyText(txt=self.label, color=self.label_color),
+                    TBodyText(txt=self.label, color=self.label_color),
                     Row(
                         [
                             self.day_dropdown,
@@ -566,12 +566,12 @@ class AlertDisplayPopUp(DialogHandler):
                 content=Column(
                     scroll=utils.AUTO_SCROLL,
                     controls=[
-                        StdHeading(
+                        THeading(
                             title=title,
                             size=fonts.HEADLINE_4_SIZE,
                         ),
                         Spacer(xs_space=True),
-                        StdBodyText(
+                        TBodyText(
                             txt=description,
                             size=fonts.SUBTITLE_1_SIZE,
                             color=colors.ERROR_COLOR if is_error else None,
@@ -580,7 +580,7 @@ class AlertDisplayPopUp(DialogHandler):
                 ),
             ),
             actions=[
-                StdPrimaryButton(
+                TPrimaryButton(
                     label=button_label, on_click=self.on_complete_btn_clicked
                 ),
             ],
@@ -615,12 +615,12 @@ class ConfirmDisplayPopUp(DialogHandler):
                 content=Column(
                     scroll=utils.AUTO_SCROLL,
                     controls=[
-                        StdHeading(
+                        THeading(
                             title=title,
                             size=fonts.HEADLINE_4_SIZE,
                         ),
                         Spacer(xs_space=True),
-                        StdBodyText(
+                        TBodyText(
                             txt=description,
                             size=fonts.SUBTITLE_1_SIZE,
                         ),
@@ -628,10 +628,10 @@ class ConfirmDisplayPopUp(DialogHandler):
                 ),
             ),
             actions=[
-                StdSecondaryButton(
+                TSecondaryButton(
                     label=cancel_button_label, on_click=self.on_cancel_btn_clicked
                 ),
-                StdPrimaryButton(
+                TPrimaryButton(
                     label=proceed_button_label, on_click=self.on_proceed_btn_clicked
                 ),
             ],
@@ -651,7 +651,7 @@ class ConfirmDisplayPopUp(DialogHandler):
         self.on_proceed_callback(self.data_on_confirmed)
 
 
-class StdPopUpMenuItem(PopupMenuItem):
+class TPopUpMenuItem(PopupMenuItem):
     """Returns a customizable pop up menu item with standard styling"""
 
     def __init__(
@@ -669,7 +669,7 @@ class StdPopUpMenuItem(PopupMenuItem):
                         size=dimens.ICON_SIZE,
                         color=colors.ERROR_COLOR if is_delete else None,
                     ),
-                    StdBodyText(
+                    TBodyText(
                         txt,
                         size=fonts.BUTTON_SIZE,
                         color=colors.ERROR_COLOR if is_delete else None,
@@ -680,7 +680,7 @@ class StdPopUpMenuItem(PopupMenuItem):
         )
 
 
-class StdContextMenu(PopupMenuButton):
+class TContextMenu(PopupMenuButton):
     """Returns a customizable pop up menu button with optional view, edit and delete menus"""
 
     def __init__(
@@ -700,13 +700,13 @@ class StdContextMenu(PopupMenuButton):
             items.extend(prefix_menu_items)
         if on_click_view:
             items.append(
-                StdPopUpMenuItem(
+                TPopUpMenuItem(
                     icons.VISIBILITY_OUTLINED, txt=view_item_lbl, on_click=on_click_view
                 ),
             )
         if on_click_edit:
             items.append(
-                StdPopUpMenuItem(
+                TPopUpMenuItem(
                     icons.EDIT_OUTLINED,
                     txt=edit_item_lbl,
                     on_click=on_click_edit,
@@ -714,7 +714,7 @@ class StdContextMenu(PopupMenuButton):
             )
         if on_click_delete:
             items.append(
-                StdPopUpMenuItem(
+                TPopUpMenuItem(
                     icons.DELETE_OUTLINE,
                     txt=delete_item_lbl,
                     on_click=on_click_delete,
@@ -726,7 +726,7 @@ class StdContextMenu(PopupMenuButton):
         super().__init__(items=items)
 
 
-class StdStatusDisplay(Row):
+class TStatusDisplay(Row):
     """Returns a text with a checked prefix icon"""
 
     def __init__(
@@ -743,7 +743,7 @@ class StdStatusDisplay(Row):
                     size=dimens.SM_ICON_SIZE,
                     color=colors.PRIMARY_COLOR if is_done else colors.GRAY_COLOR,
                 ),
-                StdBodyText(txt),
+                TBodyText(txt),
             ]
         )
 
@@ -771,9 +771,7 @@ class OrView(Row):
                     alignment=alignment.center,
                     visible=show_lines,
                 ),
-                StdBodyText(
-                    "OR", align=utils.TXT_ALIGN_CENTER, color=colors.GRAY_COLOR
-                ),
+                TBodyText("OR", align=utils.TXT_ALIGN_CENTER, color=colors.GRAY_COLOR),
                 Container(
                     height=2,
                     bgcolor=colors.GRAY_COLOR,
@@ -798,7 +796,7 @@ class NavigationMenuItem:
     on_new_intent: Optional[str] = None
 
 
-class StdNavigationMenu(NavigationRail):
+class TNavigationMenu(NavigationRail):
     """
     Returns a navigation menu for the application.
 
@@ -824,7 +822,7 @@ class StdNavigationMenu(NavigationRail):
 
         super().__init__(
             leading=Container(
-                content=StdSubHeading(
+                content=TSubHeading(
                     subtitle=title,
                     align=utils.START_ALIGNMENT,
                     expand=True,

--- a/app/error_views/page_not_found_screen.py
+++ b/app/error_views/page_not_found_screen.py
@@ -2,14 +2,14 @@ from typing import Callable
 
 from flet import Column, Container, UserControl, padding
 
-from core.abstractions import TuttleView, TuttleViewParams
+from core.abstractions import TView, TViewParams
 from core.utils import CENTER_ALIGNMENT
-from core.views import StdErrorText, StdPrimaryButton
+from core.views import TErrorText, TPrimaryButton
 from res.dimens import SPACE_MD, SPACE_STD
 
 
-class Error404Screen(TuttleView, UserControl):
-    def __init__(self, params: TuttleViewParams):
+class Error404Screen(TView, UserControl):
+    def __init__(self, params: TViewParams):
         super().__init__(params)
         self.vertical_alignment_in_parent = CENTER_ALIGNMENT
         self.horizontal_alignment_in_parent = CENTER_ALIGNMENT
@@ -21,8 +21,8 @@ class Error404Screen(TuttleView, UserControl):
                 spacing=SPACE_STD,
                 run_spacing=SPACE_STD,
                 controls=[
-                    StdErrorText("OOps! Looks like you took a wrong turn"),
-                    StdPrimaryButton(
+                    TErrorText("OOps! Looks like you took a wrong turn"),
+                    TPrimaryButton(
                         label="Go Back".upper(), on_click=self.navigate_back
                     ),
                 ],

--- a/app/home/view.py
+++ b/app/home/view.py
@@ -25,7 +25,7 @@ from clients.view import ClientsListView
 from contacts.view import ContactsListView
 from contracts.view import ContractsListView
 from core import utils, views
-from core.abstractions import DialogHandler, TuttleView, TuttleViewParams
+from core.abstractions import DialogHandler, TView, TViewParams
 from invoicing.view import InvoicingListView
 from projects.view import ProjectsListView
 from res import colors, dimens, fonts, res_utils, theme
@@ -69,7 +69,7 @@ def get_action_bar(
             controls=[
                 Row(
                     controls=[
-                        views.StdHeading(
+                        views.THeading(
                             "",
                             size=fonts.HEADLINE_4_SIZE,
                         )
@@ -135,7 +135,7 @@ def get_action_bar(
 class MainMenuItemsHandler:
     """Manages home's main-menu items"""
 
-    def __init__(self, params: TuttleViewParams):
+    def __init__(self, params: TViewParams):
         super().__init__()
         self.menu_title = "My Business"
         self.projects_view = ProjectsListView(params)
@@ -193,7 +193,7 @@ class MainMenuItemsHandler:
 class SecondaryMenuHandler:
     """Manages home's secondary side-menu items"""
 
-    def __init__(self, params: TuttleViewParams):
+    def __init__(self, params: TViewParams):
         super().__init__()
         self.menu_title = "Workflows"
 
@@ -222,12 +222,12 @@ class SecondaryMenuHandler:
         ]
 
 
-class HomeScreen(TuttleView, UserControl):
+class HomeScreen(TView, UserControl):
     """The home screen"""
 
     def __init__(
         self,
-        params: TuttleViewParams,
+        params: TViewParams,
     ):
         super().__init__(params)
         self.keep_back_stack = False
@@ -239,12 +239,12 @@ class HomeScreen(TuttleView, UserControl):
         )
         self.selected_tab = 0
 
-        self.main_menu = views.StdNavigationMenu(
+        self.main_menu = views.TNavigationMenu(
             title=self.main_menu_handler.menu_title,
             destinations=self.get_menu_destinations(),
             on_change=lambda e: self.on_menu_destination_change(e),
         )
-        self.secondary_menu = views.StdNavigationMenu(
+        self.secondary_menu = views.TNavigationMenu(
             title=self.secondary_menu_handler.menu_title,
             destinations=self.get_menu_destinations(menu_level=1),
             on_change=lambda e: self.on_menu_destination_change(e, menu_level=1),
@@ -276,7 +276,7 @@ class HomeScreen(TuttleView, UserControl):
                     item.selected_icon,
                     size=dimens.ICON_SIZE,
                 ),
-                label_content=views.StdBodyText(item.label),
+                label_content=views.TBodyText(item.label),
                 padding=padding.symmetric(horizontal=dimens.SPACE_SM),
             )
             items.append(itemDestination)
@@ -316,12 +316,12 @@ class HomeScreen(TuttleView, UserControl):
 
     def on_resume_after_back_pressed(self):
         """called when the user presses the back button"""
-        if self.destination_view and isinstance(self.destination_view, TuttleView):
+        if self.destination_view and isinstance(self.destination_view, TView):
             self.destination_view.on_resume_after_back_pressed()
 
     def pass_intent_to_destination(self, intent: str, data: Optional[any] = None):
         """pass an intent to the destination view"""
-        if self.destination_view and isinstance(self.destination_view, TuttleView):
+        if self.destination_view and isinstance(self.destination_view, TView):
             self.destination_view.parent_intent_listener(intent, data)
 
     def on_view_notifications_clicked(self, e):
@@ -340,7 +340,7 @@ class HomeScreen(TuttleView, UserControl):
         )
         self.footer = Container(
             col={"xs": 12},
-            content=views.StdHeading(),
+            content=views.THeading(),
             alignment=alignment.center,
             border=border.only(
                 top=border.BorderSide(width=0.2, color=colors.BORDER_DARK_COLOR)

--- a/app/invoicing/view.py
+++ b/app/invoicing/view.py
@@ -15,7 +15,7 @@ from flet import (
 )
 
 from core import utils, views
-from core.abstractions import DialogHandler, TuttleView, TuttleViewParams
+from core.abstractions import DialogHandler, TView, TViewParams
 from core.intent_result import IntentResult
 from loguru import logger
 from pandas import DataFrame
@@ -72,7 +72,7 @@ class InvoicingEditorPopUp(DialogHandler, UserControl):
         self.to_date_field = views.DateSelector(
             label="To", initial_date=today, label_color=colors.GRAY_COLOR
         )
-        self.projects_dropdown = views.StdDropDown(
+        self.projects_dropdown = views.TDropDown(
             on_change=self.on_project_selected,
             label="Select project",
             items=project_options,
@@ -85,9 +85,9 @@ class InvoicingEditorPopUp(DialogHandler, UserControl):
                 content=Column(
                     scroll=utils.AUTO_SCROLL,
                     controls=[
-                        views.StdHeading(title=title, size=fonts.HEADLINE_4_SIZE),
+                        views.THeading(title=title, size=fonts.HEADLINE_4_SIZE),
                         views.Spacer(xs_space=True),
-                        views.StdTextField(
+                        views.TTextField(
                             label="Invoice Number",
                             hint=self.invoice.number,
                             initial_value=self.invoice.number,
@@ -99,7 +99,7 @@ class InvoicingEditorPopUp(DialogHandler, UserControl):
                         views.Spacer(xs_space=True),
                         self.projects_dropdown,
                         views.Spacer(),
-                        views.StdBodyText(txt="Date range"),
+                        views.TBodyText(txt="Date range"),
                         self.from_date_field,
                         self.to_date_field,
                         views.Spacer(xs_space=True),
@@ -107,9 +107,7 @@ class InvoicingEditorPopUp(DialogHandler, UserControl):
                 ),
             ),
             actions=[
-                views.StdPrimaryButton(
-                    label="Done", on_click=self.on_submit_btn_clicked
-                ),
+                views.TPrimaryButton(label="Done", on_click=self.on_submit_btn_clicked),
             ],
         )
         super().__init__(dialog=dialog, dialog_controller=dialog_controller)
@@ -134,10 +132,10 @@ class InvoicingEditorPopUp(DialogHandler, UserControl):
         self.on_submit(self.invoice, self.project, from_date, to_date)
 
 
-class InvoicingListView(TuttleView, UserControl):
+class InvoicingListView(TView, UserControl):
     """The view for displaying the list of invoices"""
 
-    def __init__(self, params: TuttleViewParams):
+    def __init__(self, params: TViewParams):
         super().__init__(params=params)
         self.intent = InvoicingIntent(client_storage=params.client_storage)
         self.invoices_to_display = {}
@@ -381,8 +379,8 @@ class InvoicingListView(TuttleView, UserControl):
 
     def build(self):
         """build the view"""
-        self.loading_indicator = views.StdProgressBar()
-        self.no_invoices_control = views.StdBodyText(
+        self.loading_indicator = views.TProgressBar()
+        self.no_invoices_control = views.TBodyText(
             txt="You have not created any invoices yet",
             show=False,
         )
@@ -391,7 +389,7 @@ class InvoicingListView(TuttleView, UserControl):
                 Column(
                     col={"xs": 12},
                     controls=[
-                        views.StdHeading(title="Invoicing", size=fonts.HEADLINE_4_SIZE),
+                        views.THeading(title="Invoicing", size=fonts.HEADLINE_4_SIZE),
                         self.loading_indicator,
                         self.no_invoices_control,
                     ],
@@ -454,35 +452,31 @@ class InvoiceTile(UserControl):
         if self.invoice.contract and self.invoice.contract.client:
             _client_name = self.invoice.contract.client.name
         return ListTile(
-            leading=views.StdBodyText(self.invoice.number),
-            title=views.StdBodyText(f"{_project_title} ➡ {_client_name}"),
+            leading=views.TBodyText(self.invoice.number),
+            title=views.TBodyText(f"{_project_title} ➡ {_client_name}"),
             subtitle=Column(
                 controls=[
-                    views.StdBodyText(
+                    views.TBodyText(
                         f'Invoice Date: {self.invoice.date.strftime("%d-%m-%Y")}'
                     ),
                     Row(
                         controls=[
-                            views.StdBodyText(
+                            views.TBodyText(
                                 f"Total: {self.invoice.total:.2f} {_currency}"
                             ),
-                            views.StdStatusDisplay(
-                                txt="Paid", is_done=self.invoice.paid
-                            ),
-                            views.StdStatusDisplay(
+                            views.TStatusDisplay(txt="Paid", is_done=self.invoice.paid),
+                            views.TStatusDisplay(
                                 txt="Cancelled", is_done=self.invoice.cancelled
                             ),
-                            views.StdStatusDisplay(
-                                txt="Sent", is_done=self.invoice.sent
-                            ),
+                            views.TStatusDisplay(txt="Sent", is_done=self.invoice.sent),
                         ]
                     ),
                 ]
             ),
-            trailing=views.StdContextMenu(
+            trailing=views.TContextMenu(
                 on_click_delete=lambda e: self.on_delete_clicked(self.invoice),
                 prefix_menu_items=[
-                    views.StdPopUpMenuItem(
+                    views.TPopUpMenuItem(
                         icon=icons.HOURGLASS_BOTTOM_OUTLINED,
                         txt="Mark as sent"
                         if not self.invoice.sent
@@ -491,26 +485,26 @@ class InvoiceTile(UserControl):
                             self.invoice,
                         ),
                     ),
-                    views.StdPopUpMenuItem(
+                    views.TPopUpMenuItem(
                         icon=icons.ATTACH_MONEY_OUTLINED,
                         txt="Mark as paid"
                         if not self.invoice.paid
                         else "Mark as not paid",
                         on_click=lambda e: self.toggle_paid_status(self.invoice),
                     ),
-                    views.StdPopUpMenuItem(
+                    views.TPopUpMenuItem(
                         icon=icons.CANCEL_OUTLINED,
                         txt="Mark as cancelled"
                         if not self.invoice.cancelled
                         else "Mark as not cancelled",
                         on_click=lambda e: self.toggle_cancelled_status(self.invoice),
                     ),
-                    views.StdPopUpMenuItem(
+                    views.TPopUpMenuItem(
                         icon=icons.VISIBILITY_OUTLINED,
                         txt="View",
                         on_click=lambda e: self.on_view_invoice(self.invoice),
                     ),
-                    views.StdPopUpMenuItem(
+                    views.TPopUpMenuItem(
                         icon=icons.OUTGOING_MAIL,
                         txt="Send",
                         on_click=lambda e: self.on_mail_invoice(self.invoice),

--- a/app/preferences/view.py
+++ b/app/preferences/view.py
@@ -18,7 +18,7 @@ from flet import (
 )
 
 from core import utils, views
-from core.abstractions import TuttleView, TuttleViewParams
+from core.abstractions import TView, TViewParams
 from core.intent_result import IntentResult
 
 from core.utils import (
@@ -41,10 +41,10 @@ from res.theme import THEME_MODES
 from tuttle.cloud import CloudProvider
 
 
-class PreferencesScreen(TuttleView, UserControl):
+class PreferencesScreen(TView, UserControl):
     def __init__(
         self,
-        params: TuttleViewParams,
+        params: TViewParams,
         on_theme_changed_callback: Callable,
         on_reset_app_callback: Callable,
     ):
@@ -127,7 +127,7 @@ class PreferencesScreen(TuttleView, UserControl):
                         size=dimens.ICON_SIZE,
                     ),
                     views.Spacer(sm_space=True),
-                    views.StdBodyText(txt=label),
+                    views.TBodyText(txt=label),
                     views.Spacer(md_space=True),
                 ],
             ),
@@ -141,7 +141,7 @@ class PreferencesScreen(TuttleView, UserControl):
     def build(self):
         side_bar_width = int(MIN_WINDOW_WIDTH * 0.3)
         self.body_width = int(MIN_WINDOW_WIDTH * 0.7)
-        self.loading_indicator = views.StdProgressBar()
+        self.loading_indicator = views.TProgressBar()
         self.sideBar = Container(
             padding=padding.all(SPACE_STD),
             width=side_bar_width,
@@ -156,28 +156,28 @@ class PreferencesScreen(TuttleView, UserControl):
             ),
         )
 
-        self.theme_control = views.StdDropDown(
+        self.theme_control = views.TDropDown(
             items=[mode.value for mode in THEME_MODES],
             on_change=self.on_theme_changed,
             label="Appearance",
             hint="",
         )
-        self.cloud_provider_control = views.StdDropDown(
+        self.cloud_provider_control = views.TDropDown(
             label="Cloud Provider",
             on_change=self.on_cloud_provider_selected,
             items=[item.value for item in CloudProvider],
         )
-        self.cloud_account_id_control = views.StdTextField(
+        self.cloud_account_id_control = views.TTextField(
             label="Cloud Account Name",
             hint="Your cloud account name",
             on_change=self.on_cloud_account_id_changed,
         )
-        self.currencies_control = views.StdDropDown(
+        self.currencies_control = views.TDropDown(
             label="Default Currency",
             on_change=self.on_currency_selected,
             items=self.currencies,
         )
-        self.languages_control = views.StdDropDown(
+        self.languages_control = views.TDropDown(
             label="Language",
             on_change=self.on_language_selected,
             items=[
@@ -186,7 +186,7 @@ class PreferencesScreen(TuttleView, UserControl):
         )
 
         # a reset button for the app with a warning sign, warning color and a confirmation dialog
-        self.reset_button = views.StdDangerButton(
+        self.reset_button = views.TDangerButton(
             label="Reset App and Quit",
             icon=icons.RESTART_ALT_OUTLINED,
             on_click=self.on_reset_app,
@@ -212,7 +212,7 @@ class PreferencesScreen(TuttleView, UserControl):
                     "Cloud",
                     icons.CLOUD_OUTLINED,
                     [
-                        views.StdBodyText(
+                        views.TBodyText(
                             txt="Setting up your cloud account will enable you to import time tracking data from your cloud calendar.",
                         ),
                         views.Spacer(sm_space=True),
@@ -241,7 +241,7 @@ class PreferencesScreen(TuttleView, UserControl):
                                 icons.SETTINGS_SUGGEST_OUTLINED,
                                 size=dimens.ICON_SIZE,
                             ),
-                            views.StdHeading(
+                            views.THeading(
                                 title="Preferences",
                             ),
                         ],

--- a/app/projects/view.py
+++ b/app/projects/view.py
@@ -25,7 +25,7 @@ from flet import (
 
 from clients.view import ClientViewPopUp
 from core import utils, views
-from core.abstractions import TuttleView, TuttleViewParams
+from core.abstractions import TView, TViewParams
 from core.intent_result import IntentResult
 from projects.intent import ProjectsIntent
 from res import colors, dimens, fonts, res_utils
@@ -60,13 +60,13 @@ class ProjectCard(UserControl):
                     utils.TuttleComponentIcons.project_icon,
                     size=dimens.ICON_SIZE,
                 ),
-                title=views.StdBodyText(self.project.title),
-                subtitle=views.StdBodyText(
+                title=views.TBodyText(self.project.title),
+                subtitle=views.TBodyText(
                     f"#{self.project.tag}",
                     color=colors.GRAY_COLOR,
                     weight=FontWeight.BOLD,
                 ),
-                trailing=views.StdContextMenu(
+                trailing=views.TContextMenu(
                     on_click_view=lambda e: self.on_view_details_clicked(
                         self.project.id
                     ),
@@ -78,13 +78,13 @@ class ProjectCard(UserControl):
             views.Spacer(md_space=True),
             ResponsiveRow(
                 controls=[
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt="Brief Description",
                         color=colors.GRAY_COLOR,
                         size=fonts.BODY_2_SIZE,
                         col={"xs": "12"},
                     ),
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt=self.project.get_brief_description(),
                         col={"xs": "12"},
                     ),
@@ -96,14 +96,14 @@ class ProjectCard(UserControl):
             views.Spacer(md_space=True),
             ResponsiveRow(
                 controls=[
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt="Client",
                         color=colors.GRAY_COLOR,
                         size=fonts.BODY_2_SIZE,
                         col={"xs": "12"},
                     ),
                     Container(
-                        views.StdBodyText(
+                        views.TBodyText(
                             txt=_client_title,
                             col={"xs": "12"},
                         ),
@@ -117,14 +117,14 @@ class ProjectCard(UserControl):
             views.Spacer(md_space=True),
             ResponsiveRow(
                 controls=[
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt="Contract",
                         color=colors.GRAY_COLOR,
                         size=fonts.BODY_2_SIZE,
                         col={"xs": "12"},
                     ),
                     Container(
-                        views.StdBodyText(
+                        views.TBodyText(
                             txt=_contract_title,
                             col={"xs": "12"},
                         ),
@@ -138,14 +138,14 @@ class ProjectCard(UserControl):
             views.Spacer(md_space=True),
             ResponsiveRow(
                 controls=[
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt="Start date",
                         color=colors.GRAY_COLOR,
                         size=fonts.BODY_2_SIZE,
                         col={"xs": "12"},
                     ),
                     Container(
-                        views.StdBodyText(
+                        views.TBodyText(
                             txt=self.project.start_date.strftime("%d/%m/%Y")
                             if self.project.start_date
                             else "",
@@ -161,14 +161,14 @@ class ProjectCard(UserControl):
             views.Spacer(md_space=True),
             ResponsiveRow(
                 controls=[
-                    views.StdBodyText(
+                    views.TBodyText(
                         txt="End date",
                         color=colors.GRAY_COLOR,
                         size=fonts.BODY_2_SIZE,
                         col={"xs": "12"},
                     ),
                     Container(
-                        views.StdBodyText(
+                        views.TBodyText(
                             txt=self.project.end_date.strftime("%d/%m/%Y")
                             if self.project.end_date
                             else "-",
@@ -298,18 +298,18 @@ class ProjectFiltersView(UserControl):
         return self.filters
 
 
-class ViewProjectScreen(TuttleView, UserControl):
+class ViewProjectScreen(TView, UserControl):
     """View project screen"""
 
     def __init__(
         self,
-        params: TuttleViewParams,
+        params: TViewParams,
         project_id: str,
     ):
         super().__init__(params)
         self.intent = ProjectsIntent()
         self.project_id = project_id
-        self.loading_indicator = views.StdProgressBar()
+        self.loading_indicator = views.TProgressBar()
         self.project: Optional[Project] = None
         self.pop_up_handler = None
 
@@ -436,31 +436,31 @@ class ViewProjectScreen(TuttleView, UserControl):
             on_click=self.on_delete_clicked,
         )
 
-        self.project_title_control = views.StdHeading()
+        self.project_title_control = views.THeading()
 
-        self.client_control = views.StdSubHeading(
+        self.client_control = views.TSubHeading(
             color=colors.GRAY_COLOR,
         )
-        self.contract_control = views.StdSubHeading(
+        self.contract_control = views.TSubHeading(
             color=colors.GRAY_COLOR,
         )
-        self.project_description_control = views.StdBodyText(
+        self.project_description_control = views.TBodyText(
             align=utils.TXT_ALIGN_JUSTIFY,
         )
 
-        self.project_start_date_control = views.StdSubHeading(
+        self.project_start_date_control = views.TSubHeading(
             size=fonts.BUTTON_SIZE,
             color=colors.GRAY_COLOR,
         )
-        self.project_end_date_control = views.StdSubHeading(
+        self.project_end_date_control = views.TSubHeading(
             size=fonts.BUTTON_SIZE,
             color=colors.GRAY_COLOR,
         )
 
-        self.project_status_control = views.StdSubHeading(
+        self.project_status_control = views.TSubHeading(
             size=fonts.BUTTON_SIZE, color=colors.PRIMARY_COLOR
         )
-        self.project_tagline_control = views.StdSubHeading(
+        self.project_tagline_control = views.TSubHeading(
             size=fonts.BUTTON_SIZE, color=colors.PRIMARY_COLOR
         )
 
@@ -510,7 +510,7 @@ class ViewProjectScreen(TuttleView, UserControl):
                                                 vertical_alignment=utils.CENTER_ALIGNMENT,
                                                 alignment=utils.SPACE_BETWEEN_ALIGNMENT,
                                                 controls=[
-                                                    views.StdHeading(
+                                                    views.THeading(
                                                         "Project",
                                                         size=fonts.HEADLINE_4_SIZE,
                                                         color=colors.PRIMARY_COLOR,
@@ -536,7 +536,7 @@ class ViewProjectScreen(TuttleView, UserControl):
                                 ],
                             ),
                             views.Spacer(md_space=True),
-                            views.StdSubHeading(
+                            views.TSubHeading(
                                 subtitle="Project Description",
                             ),
                             self.project_description_control,
@@ -604,14 +604,14 @@ class ViewProjectScreen(TuttleView, UserControl):
             self.pop_up_handler.dimiss_open_dialogs()
 
 
-class ProjectsListView(TuttleView, UserControl):
+class ProjectsListView(TView, UserControl):
     """View for displaying a list of projects"""
 
     def __init__(self, params):
         super().__init__(params)
         self.intent = ProjectsIntent()
-        self.loading_indicator = views.StdProgressBar()
-        self.no_projects_control = views.StdBodyText(
+        self.loading_indicator = views.TProgressBar()
+        self.no_projects_control = views.TBodyText(
             txt="You have not added any projects yet.",
             color=colors.ERROR_COLOR,
             show=False,
@@ -621,9 +621,7 @@ class ProjectsListView(TuttleView, UserControl):
                 Column(
                     col={"xs": 12},
                     controls=[
-                        views.StdHeading(
-                            title="My Projects", size=fonts.HEADLINE_4_SIZE
-                        ),
+                        views.THeading(title="My Projects", size=fonts.HEADLINE_4_SIZE),
                         self.loading_indicator,
                         self.no_projects_control,
                     ],
@@ -750,12 +748,12 @@ class ProjectsListView(TuttleView, UserControl):
         self.mounted = False
 
 
-class ProjectEditorScreen(TuttleView, UserControl):
+class ProjectEditorScreen(TView, UserControl):
     """Displays a form for creating or updating a project"""
 
     def __init__(
         self,
-        params: TuttleViewParams,
+        params: TViewParams,
         project_id_if_editing: Optional[str] = None,
     ):
         super().__init__(params)
@@ -764,7 +762,7 @@ class ProjectEditorScreen(TuttleView, UserControl):
         self.project_id_if_editing = project_id_if_editing
         self.old_project_if_editing: Optional[Project] = None
         self.contracts_map = {}
-        self.loading_indicator = views.StdProgressBar()
+        self.loading_indicator = views.TProgressBar()
         self.title = ""
         self.description = ""
         self.tag = ""
@@ -944,25 +942,25 @@ class ProjectEditorScreen(TuttleView, UserControl):
 
     def build(self):
         """Builds the view"""
-        self.title_field = views.StdTextField(
+        self.title_field = views.TTextField(
             label="Title",
             hint="A short, unique title",
             on_change=self.on_title_changed,
             on_focus=self.clear_title_error,
         )
-        self.description_field = views.StdMultilineField(
+        self.description_field = views.TMultilineField(
             label="Description",
             hint="A longer description of the project",
             on_change=self.on_description_changed,
             on_focus=self.clear_description_error,
         )
-        self.tag_field = views.StdTextField(
+        self.tag_field = views.TTextField(
             label="Tag",
             hint="A unique tag",
             on_change=self.on_tag_changed,
         )
 
-        self.contracts_field = views.StdDropDown(
+        self.contracts_field = views.TDropDown(
             label="Contract",
             on_change=self.on_contract_selected,
             items=self.get_contracts_as_list(),
@@ -983,10 +981,10 @@ class ProjectEditorScreen(TuttleView, UserControl):
             ],
         )
 
-        self.form_title = views.StdHeading(
+        self.form_title = views.THeading(
             title="New Project",
         )
-        self.submit_btn = views.StdPrimaryButton(
+        self.submit_btn = views.TPrimaryButton(
             label="Create Project",
             on_click=self.on_save,
         )

--- a/app/timetracking/view.py
+++ b/app/timetracking/view.py
@@ -16,7 +16,7 @@ from flet import (
 )
 
 from core import tabular, utils, views
-from core.abstractions import DialogHandler, TuttleView
+from core.abstractions import DialogHandler, TView
 from core.intent_result import IntentResult
 from pandas import DataFrame
 from res import colors, dimens, fonts, res_utils
@@ -44,9 +44,9 @@ class TwoFAPopUp(DialogHandler):
                 content=Column(
                     scroll=utils.AUTO_SCROLL,
                     controls=[
-                        views.StdHeading(title=title, size=fonts.HEADLINE_4_SIZE),
+                        views.THeading(title=title, size=fonts.HEADLINE_4_SIZE),
                         views.Spacer(xs_space=True),
-                        views.StdTextField(
+                        views.TTextField(
                             label="Code",
                             on_change=self.on_code_changed,
                         ),
@@ -56,7 +56,7 @@ class TwoFAPopUp(DialogHandler):
                 width=dialog_width,
             ),
             actions=[
-                views.StdPrimaryButton(
+                views.TPrimaryButton(
                     label="Verify",
                     on_click=lambda e: on_submit_callback(self.code),
                 ),
@@ -94,20 +94,20 @@ class NewTimeTrackPopUp(DialogHandler):
                 content=Column(
                     scroll=utils.AUTO_SCROLL,
                     controls=[
-                        views.StdHeading(title=title, size=fonts.HEADLINE_4_SIZE),
+                        views.THeading(title=title, size=fonts.HEADLINE_4_SIZE),
                         views.Spacer(xs_space=True),
-                        views.StdBodyText(
+                        views.TBodyText(
                             f"Use calendar from {preferred_acc_provider}",
                             show=display_cloud_option,
                         ),
                         space_between_cloud_controls,
-                        views.StdTextField(
+                        views.TTextField(
                             label="Calendar Name",
                             on_change=self.on_calendar_name_changed,
                             show=display_cloud_option,
                         ),
                         space_between_cloud_controls,
-                        views.StdTextField(
+                        views.TTextField(
                             label="Cloud Password",
                             hint="Your password will not be stored",
                             keyboard_type=utils.KEYBOARD_PASSWORD,
@@ -115,7 +115,7 @@ class NewTimeTrackPopUp(DialogHandler):
                             show=display_cloud_option,
                         ),
                         space_between_cloud_controls,
-                        views.StdPrimaryButton(
+                        views.TPrimaryButton(
                             label="Load from cloud calendar",
                             icon="cloud",
                             on_click=lambda e: on_use_cloud_acc_callback(
@@ -130,7 +130,7 @@ class NewTimeTrackPopUp(DialogHandler):
                         space_between_cloud_controls,
                         views.OrView(show_lines=False, show=display_cloud_option),
                         space_between_cloud_controls,
-                        views.StdSecondaryButton(
+                        views.TSecondaryButton(
                             label="Upload a calendar (.ics) file",
                             icon="calendar_month",
                             on_click=lambda _: on_use_file_callback(is_ics=True),
@@ -138,7 +138,7 @@ class NewTimeTrackPopUp(DialogHandler):
                         ),
                         views.OrView(show_lines=False),
                         views.Spacer(xs_space=True),
-                        views.StdSecondaryButton(
+                        views.TSecondaryButton(
                             label="Upload a spreadsheet",
                             icon="table_view",
                             on_click=lambda _: on_use_file_callback(
@@ -163,7 +163,7 @@ class NewTimeTrackPopUp(DialogHandler):
         self.password = e.control.value
 
 
-class TimeTrackingView(TuttleView, UserControl):
+class TimeTrackingView(TView, UserControl):
     """Time tracking view on home page"""
 
     def __init__(self, params):
@@ -438,19 +438,19 @@ class TimeTrackingView(TuttleView, UserControl):
         self.update_self()
 
     def build(self):
-        self.loading_indicator = views.StdProgressBar()
-        self.no_timetrack_control = views.StdBodyText(
+        self.loading_indicator = views.TProgressBar()
+        self.no_timetrack_control = views.TBodyText(
             txt="You have not logged any work progress yet.",
             color=colors.ERROR_COLOR,
             show=False,
         )
-        self.ongoing_action_hint = views.StdBodyText(show=False)
+        self.ongoing_action_hint = views.TBodyText(show=False)
         self.title_control = ResponsiveRow(
             controls=[
                 Column(
                     col={"xs": 12},
                     controls=[
-                        views.StdHeading(
+                        views.THeading(
                             title="Time Tracking", size=fonts.HEADLINE_4_SIZE
                         ),
                         self.loading_indicator,


### PR DESCRIPTION
Custom controls derived from flet controls which are specific to this project should be prefixed with T, e.g.

 ```python
 class TTextField(TextField):
 ```