### PR TITLE
fix: home screen sidebar width is fixed

### DIFF
--- a/app/core/views.py
+++ b/app/core/views.py
@@ -887,7 +887,7 @@ class TNavigationMenuNoLeading(UserControl):
         on_change,
         selected_index: Optional[int] = 0,
         destinations=[],
-        menu_height: int = 300,
+        menu_height: int = 200,
         width: int = int(dimens.MIN_WINDOW_WIDTH * 0.3),
         left_padding: int = dimens.SPACE_STD,
         top_margin: int = dimens.SPACE_STD,

--- a/app/core/views.py
+++ b/app/core/views.py
@@ -869,6 +869,73 @@ class TNavigationMenu(NavigationRail):
         )
 
 
+class TNavigationMenuNoLeading(UserControl):
+    """
+    Returns a navigation menu for the application without a leading content.
+
+    :param title: Title of the navigation menu.
+    :param on_change: Callable function to be called when the selected item in the menu changes.
+    :param selected_index: The index of the selected item in the menu.
+    :param destinations: List of destinations in the menu.
+    :param menu_height: The height of the menu.
+    :return: A NavigationRail widget containing the navigation menu.
+    """
+
+    def __init__(
+        self,
+        title: str,
+        on_change,
+        selected_index: Optional[int] = 0,
+        destinations=[],
+        menu_height: int = 300,
+        width: int = int(dimens.MIN_WINDOW_WIDTH * 0.3),
+        left_padding: int = dimens.SPACE_STD,
+        top_margin: int = dimens.SPACE_STD,
+    ):
+
+        super().__init__()
+        self.titleContainer = Container(
+            content=TSubHeading(
+                subtitle=title,
+                align=utils.TXT_ALIGN_LEFT,
+                expand=True,
+                color=colors.GRAY_DARK_COLOR,
+            ),
+            expand=False,
+            width=width,
+            alignment=alignment.center_left,
+            margin=margin.only(top=top_margin),
+            padding=padding.only(left=left_padding),
+        )
+        self.navigationRail = NavigationRail(
+            selected_index=selected_index,
+            min_width=utils.COMPACT_RAIL_WIDTH,
+            extended=True,
+            height=menu_height,
+            min_extended_width=width,
+            destinations=destinations,
+            on_change=on_change,
+        )
+
+    def setBgColor(self, side_bar_bg_color):
+        # set the background color of the navigation menu
+        self.navigationRail.bgcolor = side_bar_bg_color
+        self.titleContainer.bgcolor = side_bar_bg_color
+        self.update()
+
+    def build(self):
+        return Column(
+            controls=[
+                self.titleContainer,
+                self.navigationRail,
+            ],
+            alignment=utils.START_ALIGNMENT,
+            horizontal_alignment=utils.START_ALIGNMENT,
+            spacing=0,
+            run_spacing=0,
+        )
+
+
 class THomeGrid(GridView):
     """Returns a grid view used in the home screen"""
 

--- a/app/home/view.py
+++ b/app/home/view.py
@@ -222,6 +222,8 @@ class SecondaryMenuHandler:
         ]
 
 
+
+SIDEBAR_WIDTH = 250 # width of the sidebar menu in home screen
 class HomeScreen(TView, UserControl):
     """The home screen"""
 
@@ -347,21 +349,19 @@ class HomeScreen(TView, UserControl):
             ),
             height=dimens.FOOTER_HEIGHT,
         )
-        self.main_body = Column(
-            col={
-                "xs": 8,
-                "md": 9,
-                "lg": 10,
-            },
-            alignment=utils.START_ALIGNMENT,
-            horizontal_alignment=utils.START_ALIGNMENT,
-            controls=[
-                self.action_bar,
-                self.destination_content_container,
-            ],
+        self.main_body = Container(
+            width=dimens.MIN_WINDOW_WIDTH - SIDEBAR_WIDTH,
+            content=Column(
+                alignment=utils.START_ALIGNMENT,
+                horizontal_alignment=utils.START_ALIGNMENT,
+                controls=[
+                    self.action_bar,
+                    self.destination_content_container,
+                ],
+            ),
         )
         self.side_bar = Container(
-            col={"xs": 4, "md": 3, "lg": 2},
+            width=SIDEBAR_WIDTH,
             padding=padding.only(top=dimens.SPACE_XL),
             content=Column(
                 controls=[
@@ -384,7 +384,7 @@ class HomeScreen(TView, UserControl):
         self.home_screen_view = Container(
             Column(
                 [
-                    ResponsiveRow(
+                    Row(
                         controls=[
                             self.side_bar,
                             self.main_body,
@@ -443,6 +443,7 @@ class HomeScreen(TView, UserControl):
             self.action_bar.height + self.footer.height + 50
         )
         self.destination_content_container.height = DESTINATION_CONTENT_PERCENT_HEIGHT
+        self.main_body.width = self.page_width - SIDEBAR_WIDTH
         self.update_self()
 
     def will_unmount(self):

--- a/app/home/view.py
+++ b/app/home/view.py
@@ -241,15 +241,17 @@ class HomeScreen(TView, UserControl):
         )
         self.selected_tab = 0
 
-        self.main_menu = views.TNavigationMenu(
+        self.main_menu = views.TNavigationMenuNoLeading(
             title=self.main_menu_handler.menu_title,
             destinations=self.get_menu_destinations(),
             on_change=lambda e: self.on_menu_destination_change(e),
+            
         )
-        self.secondary_menu = views.TNavigationMenu(
+        self.secondary_menu = views.TNavigationMenuNoLeading(
             title=self.secondary_menu_handler.menu_title,
             destinations=self.get_menu_destinations(menu_level=1),
             on_change=lambda e: self.on_menu_destination_change(e, menu_level=1),
+    
         )
         self.current_menu_handler = self.main_menu_handler
         self.destination_view = self.current_menu_handler.items[0].destination
@@ -362,7 +364,10 @@ class HomeScreen(TView, UserControl):
         )
         self.side_bar = Container(
             width=SIDEBAR_WIDTH,
-            padding=padding.only(top=dimens.SPACE_XL),
+            padding=padding.only(
+            top=dimens.SPACE_XL,
+            left=0,
+            ),
             content=Column(
                 controls=[
                     self.main_menu,
@@ -419,18 +424,14 @@ class HomeScreen(TView, UserControl):
             self.show_snack(result.error_msg, is_error=True)
             return
         self.preferred_theme = result.data
-        side_bar_components = [
-            self.side_bar,
-            self.main_menu,
-            self.secondary_menu,
-        ]
         side_bar_bg_color = colors.SIDEBAR_DARK_COLOR  # default is dark mode
         self.action_bar.bgcolor = colors.ACTION_BAR_DARK_COLOR
         if self.preferred_theme == theme.THEME_MODES.light.value:
             side_bar_bg_color = colors.SIDEBAR_LIGHT_COLOR
             self.action_bar.bgcolor = colors.ACTION_BAR_LIGHT_COLOR
-        for component in side_bar_components:
-            component.bgcolor = side_bar_bg_color
+        self.side_bar.bgcolor = side_bar_bg_color
+        self.main_menu.setBgColor(side_bar_bg_color)
+        self.secondary_menu.setBgColor(side_bar_bg_color)
         self.footer.bgcolor = side_bar_bg_color  # footer and side bar have same bgcolor
         self.update_self()
 


### PR DESCRIPTION
- [x] The width of the side menu bar currently changes with the window size. Native look&feel requires a fixed width side bar.
- [x] The sub-headings for grouping the menu items are not aligned to the left like in a native app.
- [x] There is a lot of space between the two sub-menus. Arrange the menus so that one follows the other immediately.