### PR TITLE
Sync project board status after list toggle

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -8,6 +8,7 @@
   "main": "dist-electron/main.js",
   "scripts": {
     "dev": "vite",
+    "test": "node test/project-board.test.mjs",
     "build": "tsc && vite build",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",

--- a/ui/src/components/business/ProjectsView.tsx
+++ b/ui/src/components/business/ProjectsView.tsx
@@ -11,6 +11,7 @@ import { ViewModeToggle } from "../shared/ViewModeToggle";
 import { KanbanBoard, useStageStore, type BoardColumn } from "../shared/KanbanBoard";
 import { useNavigation } from "../shared/NavigationContext";
 import type { Entity } from "../../api/types";
+import { projectColumnAfterCompletedToggle } from "./projectBoard";
 
 interface BudgetEntry {
   project_id: number;
@@ -117,7 +118,11 @@ export function ProjectsView() {
   }
 
   async function handleToggle(id: number) {
-    await rpc("projects.toggle_completed", { id });
+    const res = await rpc("projects.toggle_completed", { id });
+    if (res.ok) {
+      const proj = projects.find((p) => p.id === id);
+      if (proj) stageStore.setColumn(id, projectColumnAfterCompletedToggle(projectStatus(proj)));
+    }
     await load();
   }
 

--- a/ui/src/components/business/projectBoard.ts
+++ b/ui/src/components/business/projectBoard.ts
@@ -1,0 +1,3 @@
+export function projectColumnAfterCompletedToggle(currentStatus: string): string {
+  return currentStatus === "Completed" ? "Active" : "Completed";
+}

--- a/ui/test/project-board.test.mjs
+++ b/ui/test/project-board.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import {execFileSync} from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {pathToFileURL} from "node:url";
+
+const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "tuttle-project-board-"));
+const tsc = path.join("node_modules", ".bin", "tsc");
+
+execFileSync(tsc, [
+  "src/components/business/projectBoard.ts",
+  "--target", "ES2021",
+  "--module", "ES2020",
+  "--moduleResolution", "node",
+  "--outDir", outDir,
+  "--skipLibCheck",
+], {stdio: "inherit"});
+
+const modulePath = path.join(outDir, "projectBoard.js");
+const {projectColumnAfterCompletedToggle} = await import(pathToFileURL(modulePath));
+
+assert.equal(projectColumnAfterCompletedToggle("Active"), "Completed");
+assert.equal(projectColumnAfterCompletedToggle("Upcoming"), "Completed");
+assert.equal(projectColumnAfterCompletedToggle("Lead"), "Completed");
+assert.equal(projectColumnAfterCompletedToggle("Completed"), "Active");


### PR DESCRIPTION
Summary
- Update the persisted project board column after the list-view Complete button succeeds.
- Keep completed projects in the Completed column and restored projects back in Active instead of using stale localStorage state.
- Add a focused UI regression test for the project board column transition.

Tests
- cd ui && npm test
- cd ui && npm run build
- git diff --check

Fixes #268