### PR TITLE
feat(update): integrate auto-updater and UI notifications

### DIFF
--- a/.github/workflows/pack-electron.yml
+++ b/.github/workflows/pack-electron.yml
@@ -76,10 +76,11 @@ jobs:
       run: npm run build
       working-directory: ui
     - name: Package Electron app (electron-builder)
-      run: npm run dist
+      run: npx electron-builder --publish ${{ startsWith(github.ref, 'refs/tags/') && 'always' || 'never' }}
       working-directory: ui
       env:
         CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     # Artifacts (skip on merge-queue validation runs)
     - uses: actions/upload-artifact@v4
@@ -87,8 +88,3 @@ jobs:
       with:
         name: Tuttle-${{ github.ref_name }}-${{ matrix.platform }}
         path: ui/release/
-    - name: Upload release asset
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v2
-      with:
-        files: ui/release/*

--- a/ui/electron/main.ts
+++ b/ui/electron/main.ts
@@ -1,8 +1,9 @@
-import { app, BrowserWindow, ipcMain } from "electron";
+import { app, BrowserWindow, ipcMain, shell } from "electron";
 import path from "node:path";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { PythonBridge } from "./python-bridge";
+import { autoUpdater, initUpdater } from "./updater";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -82,6 +83,14 @@ app.whenReady().then(async () => {
   }
 
   createWindow();
+
+  if (!process.env.VITE_DEV_SERVER_URL && mainWindow) {
+    initUpdater(mainWindow);
+  }
+
+  ipcMain.on("quit-and-install", () => {
+    autoUpdater.quitAndInstall();
+  });
 });
 
 app.on("window-all-closed", () => {

--- a/ui/electron/preload.ts
+++ b/ui/electron/preload.ts
@@ -5,4 +5,8 @@ contextBridge.exposeInMainWorld("tuttle", {
     ipcRenderer.invoke("rpc", method, params),
   readFile: (filePath: string) => ipcRenderer.invoke("read-file", filePath),
   platform: process.platform,
+  onUpdateDownloaded: (cb: (info: { version: string }) => void) => {
+    ipcRenderer.on("update-downloaded", (_e, info) => cb(info));
+  },
+  quitAndInstall: () => ipcRenderer.send("quit-and-install"),
 });

--- a/ui/electron/updater.ts
+++ b/ui/electron/updater.ts
@@ -1,0 +1,17 @@
+import { autoUpdater } from "electron-updater";
+import type { BrowserWindow } from "electron";
+
+export { autoUpdater };
+
+export function initUpdater(win: BrowserWindow) {
+  autoUpdater.autoDownload = true;
+  autoUpdater.autoInstallOnAppQuit = false;
+
+  autoUpdater.on("update-downloaded", (info) => {
+    win.webContents.send("update-downloaded", {
+      version: info.version,
+    });
+  });
+
+  autoUpdater.checkForUpdates().catch(() => {});
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "tuttle-ui",
-  "version": "0.1.0",
+  "version": "3.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tuttle-ui",
-      "version": "0.1.0",
+      "version": "3.6.2",
       "dependencies": {
+        "electron-updater": "^6.6.2",
         "lucide-react": "^0.511.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -2665,7 +2666,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/assert-plus": {
@@ -3414,7 +3414,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3890,6 +3889,82 @@
       "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/builder-util-runtime": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+      "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
@@ -4536,7 +4611,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -4839,7 +4913,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4920,7 +4993,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lightningcss": {
@@ -5202,6 +5274,19 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5390,7 +5475,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6136,7 +6220,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -6506,6 +6589,12 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
       "license": "MIT"
     },
     "node_modules/tinyglobby": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -31,9 +31,14 @@
         "to": "tuttle-rpc"
       }
     ],
+    "publish": {
+      "provider": "github",
+      "owner": "tuttle-dev",
+      "repo": "tuttle"
+    },
     "mac": {
       "category": "public.app-category.business",
-      "target": ["dmg", "dir"],
+      "target": ["zip", "dmg", "dir"],
       "extendInfo": {
         "NSCalendarsFullAccessUsageDescription": "Tuttle needs access to your calendars to import events for time tracking."
       }
@@ -47,6 +52,7 @@
     }
   },
   "dependencies": {
+    "electron-updater": "^6.6.2",
     "lucide-react": "^0.511.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/ui/src/api/rpc.ts
+++ b/ui/src/api/rpc.ts
@@ -4,6 +4,8 @@ declare global {
       rpc: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
       readFile: (filePath: string) => Promise<{ ok: boolean; data: string | null }>;
       platform: string;
+      onUpdateDownloaded: (cb: (info: { version: string }) => void) => void;
+      quitAndInstall: () => void;
     };
   }
 }

--- a/ui/src/components/layout/Shell.tsx
+++ b/ui/src/components/layout/Shell.tsx
@@ -14,6 +14,7 @@ import { SalaryView } from "../salary/SalaryView";
 import { TimeTrackingView } from "../timetracking/TimeTrackingView";
 import { ContractImportView } from "../import/ContractImportView";
 import { PlaceholderView } from "../shared/PlaceholderView";
+import { UpdateBanner } from "./UpdateBanner";
 import { NavigationContext, type NavigationFilter } from "../shared/NavigationContext";
 import { rpc } from "../../api/rpc";
 
@@ -197,6 +198,7 @@ export function Shell() {
         />
         <main className="flex-1 flex flex-col overflow-hidden">
           <div className="drag-region h-13 shrink-0" />
+          <UpdateBanner />
           <div className="flex-1 overflow-y-auto">
             <DetailView id={selected} />
           </div>

--- a/ui/src/components/layout/UpdateBanner.tsx
+++ b/ui/src/components/layout/UpdateBanner.tsx
@@ -1,0 +1,35 @@
+import { useState, useEffect } from "react";
+import { Download, X } from "lucide-react";
+
+export function UpdateBanner() {
+  const [update, setUpdate] = useState<{ version: string } | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    window.tuttle?.onUpdateDownloaded?.((info) => setUpdate(info));
+  }, []);
+
+  if (!update || dismissed) return null;
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-2 bg-accent/10 border-b border-accent/20 text-sm text-primary shrink-0">
+      <Download size={16} className="text-accent shrink-0" />
+      <span className="flex-1">
+        Tuttle <strong>{update.version}</strong> is ready to install.
+      </span>
+      <button
+        onClick={() => window.tuttle.quitAndInstall()}
+        className="px-3 py-1 rounded-md bg-accent text-white text-xs font-medium hover:bg-accent/90 transition-colors"
+      >
+        Restart &amp; Update
+      </button>
+      <button
+        onClick={() => setDismissed(true)}
+        className="p-1 rounded hover:bg-white/10 transition-colors text-secondary"
+        aria-label="Dismiss"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
+ Add `electron-updater` for automatic updates.
+ Implement `UpdateBanner` component to notify users of available updates.
+ Modify Electron main process to initialize updater and handle update events.
+ Update `package.json` for GitHub publishing configuration.
+ Adjust packaging workflow to use `npx electron-builder` for better control.
+ Bump version: 3.6.1 → 3.6.2.