### PR TITLE
fix(einvoice): allow 0% VAT in invoice PDF generation

### DIFF
--- a/tuttle/einvoice.py
+++ b/tuttle/einvoice.py
@@ -67,6 +67,16 @@ def country_to_iso(name: str) -> str:
     return "DE"
 
 
+def _rate_to_percent(vat_rate: Decimal) -> Decimal:
+    """Convert a VAT rate fraction (0–1) to a plain xs:decimal-safe percentage.
+
+    Decimal arithmetic can produce scientific notation (e.g. 0E-10) for zero,
+    which xs:decimal rejects. Always return Decimal("0") for zero rates.
+    """
+    pct = vat_rate * 100
+    return Decimal("0") if pct == 0 else pct
+
+
 def _vat_category_code(vat_rate: Decimal) -> str:
     """Derive ZUGFeRD tax category code from a VAT rate.
 
@@ -193,13 +203,10 @@ def build_zugferd_document(
         li.delivery.billed_quantity = (quantity, unit_code)
         li.settlement.trade_tax.type_code = "VAT"
         li.settlement.trade_tax.category_code = _vat_category_code(item.VAT_rate)
-        li.settlement.trade_tax.rate_applicable_percent = Decimal(
-            str(item.VAT_rate * 100)
-        )
+        vat_pct = _rate_to_percent(item.VAT_rate)
+        li.settlement.trade_tax.rate_applicable_percent = vat_pct
         li.settlement.monetary_summation.total_amount = line_total
         doc.trade.items.add(li)
-
-        vat_pct = Decimal(str(item.VAT_rate * 100))
         tax_aggregates[vat_pct] = tax_aggregates.get(vat_pct, Decimal("0")) + line_total
 
     # -- Tax summary ----------------------------------------------------------

--- a/tuttle_tests/test_einvoice.py
+++ b/tuttle_tests/test_einvoice.py
@@ -212,6 +212,18 @@ class TestBuildZugferdDocument:
         )
         assert len(xml_bytes) > 0
 
+    def test_zero_vat_schema_validation_passes(self):
+        """0% VAT must not produce xs:decimal-invalid scientific notation (e.g. 0E-10)."""
+        user = _make_user()
+        invoice = _make_invoice()
+        for item in invoice.items:
+            item.VAT_rate = Decimal("0E-10")  # simulate what the DB can return
+        xml_bytes = serialize_zugferd_xml(
+            invoice, user, profile="EN16931", validate=True
+        )
+        assert len(xml_bytes) > 0
+        assert b"0E-10" not in xml_bytes
+
     def test_embed_in_pdf(self, tmp_path):
         """Full round-trip: generate a PDF, embed ZUGFeRD XML, verify output."""
         from pypdf import PdfWriter


### PR DESCRIPTION
## Summary

- Fixes PDF generation failure when a contract has 0% VAT
- Python `Decimal` arithmetic can produce `0E-10` (scientific notation) for zero when the ORM/DB returns a zero with a non-zero exponent; `xs:decimal` rejects this notation
- Added `_rate_to_percent()` helper that normalizes any zero `Decimal` to `Decimal("0")` before passing to drafthorse for XML serialization
- Added a regression test that explicitly sets `VAT_rate = Decimal("0E-10")` and asserts schema validation passes and the output contains no scientific notation

Closes #279

## Test plan

- [x] `uv run pytest tuttle_tests/test_einvoice.py -x -q` — all 15 tests pass, including `test_zero_vat_schema_validation_passes`
- [x] Generate an invoice PDF with a contract set to 0% VAT and confirm no error locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)