### PR TITLE
fix(projects): show currency unit in Time Budget revenue display

### DIFF
--- a/tuttle/kpi.py
+++ b/tuttle/kpi.py
@@ -363,6 +363,7 @@ def project_budget_status(
                 "hours_budget": float(hours_budget),
                 "hours_remaining": hours_remaining,
                 "planned_revenue": round(planned_revenue, 2),
+                "currency": str(contract.currency) if contract.currency else "EUR",
                 "progress": min(progress, 1.0),
                 "budget_exceeded": budget_exceeded,
             }

--- a/ui/src/components/business/ProjectsView.tsx
+++ b/ui/src/components/business/ProjectsView.tsx
@@ -21,6 +21,7 @@ interface BudgetEntry {
   hours_budget: number;
   hours_remaining: number;
   planned_revenue: number;
+  currency: string;
   progress: number;
   budget_exceeded: boolean;
 }
@@ -319,7 +320,7 @@ export function ProjectsView() {
                           <span className="text-blue-400 font-medium">{b.hours_planned.toFixed(1)}h planned</span>
                           {b.planned_revenue > 0 && (
                             <span className="ml-2 text-tertiary">
-                              ≈ {b.planned_revenue.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })} revenue
+                              ≈ {b.planned_revenue.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })} {b.currency} revenue
                             </span>
                           )}
                         </div>


### PR DESCRIPTION
## Summary

- `planned_revenue` in the Time Budget widget showed no currency unit (e.g. `≈ 240 revenue`)
- Backend `kpi.py` now includes `currency` from the contract in the budget entry
- Frontend `ProjectsView.tsx` renders `≈ 240 USD revenue` (or whichever currency)

## Validation

**Before** — currency unit missing:

<img width="188" height="79" alt="Screenshot 2026-06-09 at 11 51 54" src="https://github.com/user-attachments/assets/a194ac47-590d-4de8-a192-bbe3c95446da" />

> `2.0h planned  ≈ ░░░ revenue`

**After** — currency unit shown:

> `2.0h planned  ≈ ░░░ USD revenue`

<img width="214" height="71" alt="Screenshot 2026-06-09 at 12 01 07" src="https://github.com/user-attachments/assets/580870bb-8062-4872-8ff6-d4bfe2308b39" />


## Test plan

- [ ] Open a project with a contract that has a non-zero rate
- [ ] Verify Time Budget widget shows `≈ <amount> <currency> revenue`
- [ ] Verify projects with no planned hours show no revenue line (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)