### PR TITLE
fix: allow Electron install script for npm 11+

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -59,6 +59,9 @@
     "react-dom": "^19.1.0",
     "recharts": "^2.15.3"
   },
+  "allowScripts": {
+    "electron": true
+  },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.0",
     "@types/react": "^19.1.3",


### PR DESCRIPTION
## Summary

- Adds `allowScripts.electron = true` to `ui/package.json` so npm 11+ runs Electron's post-install binary download during `npm install`.
- Without this, the Electron binary is silently skipped, and `npm run dev` crashes with `ENOENT`.

Closes #291

## Test plan

- [ ] `cd ui && rm -rf node_modules && npm install` — verify `node_modules/electron/dist/` contains the Electron binary
- [ ] `npm run dev` — app launches without `ENOENT`

Made with [Cursor](https://cursor.com)