### PR TITLE
fix: tracked hours and revenue use calendar data instead of timesheets

### DIFF
--- a/tuttle/app/dashboard/intent.py
+++ b/tuttle/app/dashboard/intent.py
@@ -38,13 +38,16 @@ class DashboardIntent(SQLModelDataSourceMixin, Intent):
         return "Germany"
 
     def get_kpis(self) -> IntentResult:
-        """Compute KPI summary from all invoices, contracts, projects."""
+        """Compute KPI summary from invoices, contracts, and calendar data."""
         try:
             invoices = self.query(Invoice)
             contracts = self.query(Contract)
             projects = self.query(Project)
             country = self._get_country()
-            kpis = compute_kpis(invoices, contracts, projects, country=country)
+            time_data = self._time_data_source.get_data_frame()
+            kpis = compute_kpis(
+                invoices, contracts, projects, country=country, time_data=time_data
+            )
             return IntentResult(was_intent_successful=True, data=kpis)
         except Exception as e:
             return IntentResult(
@@ -159,7 +162,7 @@ class DashboardIntent(SQLModelDataSourceMixin, Intent):
             )
 
     def get_project_budgets(self) -> IntentResult:
-        """Get budget utilization for all projects, including planned hours."""
+        """Budget utilization for all projects from calendar time-tracking data."""
         try:
             projects = self.query(Project)
             time_data = self._time_data_source.get_data_frame()
@@ -179,8 +182,13 @@ class DashboardIntent(SQLModelDataSourceMixin, Intent):
             goals = self.query(FinancialGoal)
             invoices = self.query(Invoice)
             country = self._get_country()
+            time_data = self._time_data_source.get_data_frame()
             kpis = compute_kpis(
-                invoices, self.query(Contract), self.query(Project), country=country
+                invoices,
+                self.query(Contract),
+                self.query(Project),
+                country=country,
+                time_data=time_data,
             )
             ytd_revenue = float(kpis.total_revenue_ytd)
 

--- a/tuttle/forecasting.py
+++ b/tuttle/forecasting.py
@@ -153,10 +153,12 @@ def monthly_revenue_from_calendar(
     start_date: datetime.date,
     end_date: datetime.date,
 ) -> DataFrame:
-    """Forecast monthly revenue from future calendar events.
+    """Derive monthly revenue from calendar time-tracking events.
 
-    Filters *time_data* for events in [start_date, end_date], groups by month
-    and project tag, then converts hours to revenue via contract rates.
+    The calendar DataFrame is the source of truth for hours worked (past)
+    and hours planned (future).  Filters *time_data* for events in
+    [start_date, end_date], groups by month and project tag, then converts
+    hours to revenue via contract rates.
 
     Returns a DataFrame with columns: month, project, revenue, contract_id, hours.
     """
@@ -268,9 +270,13 @@ def revenue_curve_with_calendar(
     time_data: Optional[DataFrame],
     forecast_months: int = 6,
 ) -> DataFrame:
-    """Revenue curve: past invoices + future calendar allocations.
+    """Revenue curve combining invoice history with calendar-derived revenue.
 
-    Only calendar-planned time counts toward the forecast.
+    The calendar DataFrame is the source of truth for hours worked and
+    planned.  Calendar-derived revenue covers the full date range of
+    *time_data* (both past and future), so months without invoices still
+    show revenue from tracked work.  Invoice-based rows are labelled
+    ``source="actual"``; calendar-based rows ``source="calendar"``.
     """
     history = revenue_history(invoices)
     if not history.empty:
@@ -280,23 +286,25 @@ def revenue_curve_with_calendar(
         history = DataFrame(columns=["month", "revenue", "is_forecast", "source"])
 
     today = datetime.date.today()
-    forecast_start = today.replace(day=1)
     forecast_end = (
-        forecast_start + datetime.timedelta(days=30 * forecast_months)
+        today.replace(day=1) + datetime.timedelta(days=30 * forecast_months)
     ).replace(day=1)
 
     cal_monthly = DataFrame(columns=["month", "revenue", "is_forecast", "source"])
     if time_data is not None and not time_data.empty:
-        cal_forecast = monthly_revenue_from_calendar(
-            time_data, projects, forecast_start, forecast_end
+        cal_start = time_data.index.min().date().replace(day=1)
+        cal_revenue = monthly_revenue_from_calendar(
+            time_data, projects, cal_start, forecast_end
         )
-        if not cal_forecast.empty:
+        if not cal_revenue.empty:
             cal_monthly = (
-                cal_forecast.groupby("month")
+                cal_revenue.groupby("month")
                 .agg(revenue=("revenue", "sum"))
                 .reset_index()
             )
-            cal_monthly["is_forecast"] = True
+            cal_monthly["is_forecast"] = cal_monthly["month"] >= pandas.Timestamp(
+                today.replace(day=1)
+            )
             cal_monthly["source"] = "calendar"
 
     combined = pandas.concat([history, cal_monthly], ignore_index=True)

--- a/tuttle/kpi.py
+++ b/tuttle/kpi.py
@@ -61,19 +61,24 @@ def compute_kpis(
     contracts: List[Contract],
     projects: List[Project],
     country: str = "Germany",
+    time_data: Optional[DataFrame] = None,
 ) -> KPISummary:
-    """Compute business KPIs from current data."""
+    """Compute business KPIs from invoices, contracts, and calendar data.
+
+    *time_data* (the calendar DataFrame) is the source of truth for hours
+    worked.  It drives ``effective_hourly_rate`` and ``utilization_rate``.
+    Revenue metrics come from invoices.
+    """
     today = datetime.date.today()
     year_start = today.replace(month=1, day=1)
 
-    # Revenue metrics
+    # Revenue metrics (from invoices)
     total_revenue = Decimal(0)
     total_revenue_ytd = Decimal(0)
     outstanding_amount = Decimal(0)
     overdue_amount = Decimal(0)
     unpaid_invoices = 0
     overdue_invoices = 0
-    total_hours = Decimal(0)
     paid_revenue = Decimal(0)
 
     for inv in invoices:
@@ -85,11 +90,6 @@ def compute_kpis(
             total_revenue += inv_total
             if inv.date >= year_start:
                 total_revenue_ytd += inv_total
-            # Accumulate hours for effective rate calculation
-            for ts in inv.timesheets:
-                for item in ts.items:
-                    hours = item.duration.total_seconds() / 3600
-                    total_hours += Decimal(str(hours))
             paid_revenue += inv_total
         else:
             outstanding_amount += inv_total
@@ -97,6 +97,19 @@ def compute_kpis(
             if inv.due_date and inv.due_date < today:
                 overdue_amount += inv_total
                 overdue_invoices += 1
+
+    # Total tracked hours from calendar data
+    total_hours = Decimal(0)
+    if time_data is not None and not time_data.empty:
+        past = time_data[time_data.index.date < today]
+        if not past.empty:
+            tag_to_workday = {
+                p.tag: p.contract.units_per_workday
+                for p in projects
+                if p.tag and p.contract
+            }
+            tracked = sum(sum_hours_by_tag(past, tag_to_workday).values())
+            total_hours = Decimal(str(tracked))
 
     # Effective hourly rate: paid revenue / total tracked hours
     effective_hourly_rate = None
@@ -110,10 +123,8 @@ def compute_kpis(
     # Utilization rate: tracked hours / available hours (based on workdays)
     utilization_rate = None
     if active_contracts:
-        # Available hours since year start
         days_elapsed = (today - year_start).days or 1
         workdays_elapsed = int(days_elapsed * 5 / 7)
-        # Sum contracted hours per workday across active contracts
         available_hours_per_day = sum(
             c.units_per_workday for c in contracts if c.is_active()
         )
@@ -300,10 +311,11 @@ def project_budget_status(
     projects: List[Project],
     time_data: Optional[DataFrame] = None,
 ) -> list:
-    """Budget utilization for each project, including planned (future) hours.
+    """Budget utilization per project derived from calendar time-tracking data.
 
-    When *time_data* (the full calendar DataFrame) is provided, future events
-    are counted as ``hours_planned``.
+    *time_data* (the calendar DataFrame) is the source of truth for hours.
+    Past events (before today) become ``hours_tracked``; future events
+    (today onward) become ``hours_planned``.
 
     Returns a list of dicts with keys: project_id, project, hours_tracked,
     hours_planned, hours_budget, hours_remaining, planned_revenue, progress,
@@ -311,16 +323,20 @@ def project_budget_status(
     tracked or planned time.
     """
     today = datetime.date.today()
+    tracked_by_tag: dict = {}
     planned_by_tag: dict = {}
 
     if time_data is not None and not time_data.empty:
+        tag_to_workday = {
+            p.tag: p.contract.units_per_workday
+            for p in projects
+            if p.tag and p.contract
+        }
+        past = time_data[time_data.index.date < today]
+        if not past.empty:
+            tracked_by_tag = sum_hours_by_tag(past, tag_to_workday)
         future = time_data[time_data.index.date >= today]
         if not future.empty:
-            tag_to_workday = {
-                p.tag: p.contract.units_per_workday
-                for p in projects
-                if p.tag and p.contract
-            }
             planned_by_tag = sum_hours_by_tag(future, tag_to_workday)
 
     results = []
@@ -328,11 +344,7 @@ def project_budget_status(
         if not project.contract or not project.contract.volume:
             continue
 
-        hours_tracked = Decimal(0)
-        for ts in project.timesheets:
-            for item in ts.items:
-                hours_tracked += Decimal(str(item.duration.total_seconds() / 3600))
-
+        hours_tracked = Decimal(str(tracked_by_tag.get(project.tag, 0)))
         hours_planned = Decimal(str(planned_by_tag.get(project.tag, 0)))
 
         if hours_tracked == 0 and hours_planned == 0:

--- a/tuttle_tests/test_dashboard.py
+++ b/tuttle_tests/test_dashboard.py
@@ -4,6 +4,7 @@ import datetime
 from decimal import Decimal
 
 import pytest
+import pandas
 
 from tuttle.model import (
     Address,
@@ -452,20 +453,64 @@ class TestMonthlySpendableBreakdown:
         assert keys == sorted(keys)
 
 
+@pytest.fixture
+def time_data_df(project):
+    """Calendar DataFrame with past and future events tagged for the test project."""
+    today = datetime.date.today()
+    records = []
+    # 5 past events (8h each)
+    for i in range(1, 6):
+        d = today - datetime.timedelta(days=i)
+        records.append(
+            {
+                "begin": datetime.datetime(d.year, d.month, d.day, 9, 0),
+                "end": datetime.datetime(d.year, d.month, d.day, 17, 0),
+                "duration": datetime.timedelta(hours=8),
+                "title": f"Past work {i}",
+                "tag": "#TestProject",
+                "description": "",
+                "all_day": False,
+            }
+        )
+    # 2 future events (8h each)
+    for i in range(1, 3):
+        d = today + datetime.timedelta(days=i)
+        records.append(
+            {
+                "begin": datetime.datetime(d.year, d.month, d.day, 9, 0),
+                "end": datetime.datetime(d.year, d.month, d.day, 17, 0),
+                "duration": datetime.timedelta(hours=8),
+                "title": f"Future work {i}",
+                "tag": "#TestProject",
+                "description": "",
+                "all_day": False,
+            }
+        )
+    df = pandas.DataFrame(records).set_index("begin")
+    return df
+
+
 class TestProjectBudgetStatus:
     def test_project_without_volume(self, project):
         project.contract.volume = None
         result = project_budget_status([project])
         assert result == []
 
-    def test_project_with_volume_and_timesheets(self, project, timesheet_with_items):
+    def test_tracked_from_calendar_data(self, project, time_data_df):
+        """Past calendar events are the source of truth for hours_tracked."""
         project.contract.volume = 100
-        project.timesheets = [timesheet_with_items]
-        result = project_budget_status([project])
+        result = project_budget_status([project], time_data=time_data_df)
         assert len(result) == 1
         assert result[0]["project"] == "Test Project"
-        assert result[0]["hours_tracked"] > 0
+        assert result[0]["hours_tracked"] == 40.0  # 5 × 8h
+        assert result[0]["hours_planned"] == 16.0  # 2 × 8h
         assert 0 <= result[0]["progress"] <= 1.0
+
+    def test_no_time_data_yields_empty(self, project):
+        """Without calendar data no budget rows are produced."""
+        project.contract.volume = 100
+        result = project_budget_status([project], time_data=None)
+        assert result == []
 
     def test_empty_projects(self):
         result = project_budget_status([])

--- a/ui/src/components/timetracking/TimeTrackingView.tsx
+++ b/ui/src/components/timetracking/TimeTrackingView.tsx
@@ -138,7 +138,12 @@ export function TimeTrackingView() {
     for (const file of Array.from(files)) {
       if (!file.name.endsWith(".ics")) continue;
       const buffer = await file.arrayBuffer();
-      const b64 = btoa(String.fromCharCode(...new Uint8Array(buffer)));
+      const bytes = new Uint8Array(buffer);
+      let binary = "";
+      for (let i = 0; i < bytes.length; i += 8192) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + 8192));
+      }
+      const b64 = btoa(binary);
       await rpc("timetracking.import_ics", { content: b64, name: file.name });
     }
     setImporting(false);


### PR DESCRIPTION
## Summary

Fixes #294 — tracked time from imported calendar events was not appearing in the project time budget or the revenue dashboard.

The root cause: analytics (budget, KPIs, revenue curve) were reading hours from **Timesheet** objects, which are only created when generating an invoice. Calendar events — the actual source of truth for time worked — were ignored for past periods.

**What changed:**

- **Project time budget**: tracked hours now come from past calendar events, not from timesheets. Users see their hours as soon as they import a calendar — no need to invoice first.
- **KPI dashboard**: effective hourly rate and utilization rate are now based on calendar-tracked hours.
- **Revenue curve**: past months with calendar events but no invoice now show calendar-derived revenue, instead of appearing empty.

## Test plan

- [x] All 37 existing dashboard/KPI tests pass
- [x] New test verifies tracked hours are derived from calendar DataFrame (5 past events × 8h = 40h tracked, 2 future events × 8h = 16h planned)
- [ ] Manual: import an ICS file with past-month events → verify they appear in project time budget and revenue dashboard

Made with [Cursor](https://cursor.com)