### PR TITLE
fix: improve bar chart color palette for better distinction

### DIFF
--- a/ui/src/components/dashboard/DashboardView.tsx
+++ b/ui/src/components/dashboard/DashboardView.tsx
@@ -141,9 +141,9 @@ export function DashboardView() {
                 }}
               />
               <Legend wrapperStyle={{ fontSize: 12, color: "#b8b8bc" }} />
-              <Bar dataKey="invoiced" name="Invoiced" stackId="rev" fill="#3b82f6" radius={[0, 0, 0, 0]} />
-              <Bar dataKey="pending" name="Pending" stackId="rev" fill="#93c5fd" radius={[0, 0, 0, 0]} />
-              <Bar dataKey="planned" name="Planned" stackId="rev" fill="#3b82f6" opacity={0.4} radius={[3, 3, 0, 0]} />
+              <Bar dataKey="invoiced" name="Invoiced" stackId="rev" fill="#4ADE80" radius={[0, 0, 0, 0]} />
+              <Bar dataKey="pending" name="Pending" stackId="rev" fill="#FACC15" radius={[0, 0, 0, 0]} />
+              <Bar dataKey="planned" name="Planned" stackId="rev" fill="#60A5FA" radius={[3, 3, 0, 0]} />
             </ComposedChart>
           </ResponsiveContainer>
         </div>
@@ -175,7 +175,7 @@ export function DashboardView() {
                     <div className="h-full transition-all duration-300"
                       style={{
                         width: `${plannedPct * 100}%`,
-                        background: "repeating-linear-gradient(45deg, #3b82f6 0, #3b82f6 2px, transparent 2px, transparent 5px)",
+                        background: "repeating-linear-gradient(45deg, #60A5FA 0, #60A5FA 2px, transparent 2px, transparent 5px)",
                         opacity: 0.5,
                       }} />
                   )}


### PR DESCRIPTION
Closes #301

## Problem
The bar chart used three very similar shades of blue for 
Invoiced, Pending, and Planned — making them hard to distinguish.

## Changes
- Invoiced: #3b82f6 → #4ADE80 (green — money received)
- Pending:  #93c5fd → #FACC15 (amber — awaiting payment)
- Planned:  #3b82f6 → #60A5FA (distinct blue — future work)
- Updated stripe pattern color on planned progress bar to match
<img width="646" height="113" alt="Screenshot 2026-06-10 132425" src="https://github.com/user-attachments/assets/b26c6039-27f2-4af3-93f7-f15386bcc1be" />
<img width="641" height="20" alt="Screenshot 2026-06-10 132506" src="https://github.com/user-attachments/assets/434d638f-bfb4-4f92-a50b-e96bae8fd975" />
