### PR TITLE
feat(model): add ClientContact many-to-many association

### DIFF
--- a/tuttle/app/clients/intent.py
+++ b/tuttle/app/clients/intent.py
@@ -1,7 +1,7 @@
 from ..contacts.intent import ContactsIntent
 from ..core.abstractions import CrudIntent
 from ..core.intent_result import IntentResult
-from ...model import Address, Client
+from ...model import Address, Client, ClientContact
 
 
 class ClientsIntent(CrudIntent):
@@ -13,7 +13,7 @@ class ClientsIntent(CrudIntent):
         ("contracts", "contracts", lambda c: c.title),
     ]
     __save_nested__ = {"address": Address}
-    __save_skip__ = {"contracts"}
+    __save_skip__ = {"contracts", "client_contacts"}
 
     def __init__(self):
         super().__init__()
@@ -22,6 +22,72 @@ class ClientsIntent(CrudIntent):
     def get_all_contacts_as_map(self):
         """Delegate to ContactsIntent for cross-entity lookup."""
         return self._contacts_intent.get_all_as_map()
+
+    # -- ClientContact association management ----------------------------------
+
+    def get_contacts_for_client(self, client_id: int) -> IntentResult:
+        """Return all ClientContact associations for a given client."""
+        try:
+            assocs = self.query_where(ClientContact, "client_id", client_id)
+            return IntentResult(was_intent_successful=True, data=assocs)
+        except Exception as e:
+            return IntentResult(
+                was_intent_successful=False,
+                error_msg="Failed to load contacts for this client.",
+                log_message=f"get_contacts_for_client({client_id}): {e}",
+                exception=e,
+            )
+
+    def add_contact_to_client(
+        self, client_id: int, contact_id: int, role: str | None = None
+    ) -> IntentResult:
+        """Create a ClientContact association."""
+        try:
+            assoc = ClientContact(client_id=client_id, contact_id=contact_id, role=role)
+            self.store(assoc)
+            return IntentResult(was_intent_successful=True, data=assoc)
+        except Exception as e:
+            return IntentResult(
+                was_intent_successful=False,
+                error_msg="Failed to add contact to client.",
+                log_message=f"add_contact_to_client({client_id}, {contact_id}): {e}",
+                exception=e,
+            )
+
+    def remove_client_contact(self, association_id: int) -> IntentResult:
+        """Delete a ClientContact association by its id."""
+        try:
+            self.delete_by_id(ClientContact, association_id)
+            return IntentResult(was_intent_successful=True)
+        except Exception as e:
+            return IntentResult(
+                was_intent_successful=False,
+                error_msg="Failed to remove contact from client.",
+                log_message=f"remove_client_contact({association_id}): {e}",
+                exception=e,
+            )
+
+    def update_client_contact_role(
+        self, association_id: int, role: str | None
+    ) -> IntentResult:
+        """Update the role on a ClientContact association."""
+        try:
+            assoc = self.query_by_id(ClientContact, association_id)
+            if assoc is None:
+                return IntentResult(
+                    was_intent_successful=False,
+                    error_msg="Association not found.",
+                )
+            assoc.role = role
+            self.store(assoc)
+            return IntentResult(was_intent_successful=True, data=assoc)
+        except Exception as e:
+            return IntentResult(
+                was_intent_successful=False,
+                error_msg="Failed to update contact role.",
+                log_message=f"update_client_contact_role({association_id}): {e}",
+                exception=e,
+            )
 
     def _validated_save(self, client: Client) -> IntentResult:
         if not client.name:

--- a/tuttle/app/contacts/intent.py
+++ b/tuttle/app/contacts/intent.py
@@ -1,6 +1,6 @@
 from ..core.abstractions import CrudIntent
 from ..core.intent_result import IntentResult
-from ...model import Address, Contact
+from ...model import Address, Contact, ClientContact
 
 
 class ContactsIntent(CrudIntent):
@@ -12,7 +12,65 @@ class ContactsIntent(CrudIntent):
         ("invoicing_contact_of", "clients", lambda c: c.name),
     ]
     __save_nested__ = {"address": Address}
-    __save_skip__ = {"invoicing_contact_of"}
+    __save_skip__ = {"invoicing_contact_of", "client_contacts"}
+
+    def get_all_clients_as_map(self) -> dict:
+        """Return all clients as {id: {id, name}} for the association picker."""
+        from ...model import Client
+
+        try:
+            clients = self.query(Client)
+            return {c.id: {"id": c.id, "name": c.name} for c in clients}
+        except Exception:
+            return {}
+
+    def get_clients_for_contact(self, contact_id: int) -> IntentResult:
+        """Return ClientContact associations enriched with client_name."""
+        try:
+            assocs = self.query_where(ClientContact, "contact_id", contact_id)
+            result = []
+            for a in assocs:
+                d = a.model_dump()
+                if a.client:
+                    d["client_name"] = a.client.name
+                result.append(d)
+            return IntentResult(was_intent_successful=True, data=result)
+        except Exception as e:
+            return IntentResult(
+                was_intent_successful=False,
+                error_msg="Failed to load clients for this contact.",
+                log_message=f"get_clients_for_contact({contact_id}): {e}",
+                exception=e,
+            )
+
+    def add_client_to_contact(
+        self, contact_id: int, client_id: int, role: str | None = None
+    ) -> IntentResult:
+        """Create a ClientContact association from the contact side."""
+        try:
+            assoc = ClientContact(client_id=client_id, contact_id=contact_id, role=role)
+            self.store(assoc)
+            return IntentResult(was_intent_successful=True, data=assoc)
+        except Exception as e:
+            return IntentResult(
+                was_intent_successful=False,
+                error_msg="Failed to add client to contact.",
+                log_message=f"add_client_to_contact({contact_id}, {client_id}): {e}",
+                exception=e,
+            )
+
+    def remove_client_contact(self, association_id: int) -> IntentResult:
+        """Delete a ClientContact association by its id."""
+        try:
+            self.delete_by_id(ClientContact, association_id)
+            return IntentResult(was_intent_successful=True)
+        except Exception as e:
+            return IntentResult(
+                was_intent_successful=False,
+                error_msg="Failed to remove client from contact.",
+                log_message=f"remove_client_contact({association_id}): {e}",
+                exception=e,
+            )
 
     def _validated_save(self, contact: Contact) -> IntentResult:
         if not contact.first_name or not contact.last_name:

--- a/tuttle/demo.py
+++ b/tuttle/demo.py
@@ -21,6 +21,7 @@ from tuttle.model import (
     Address,
     BankAccount,
     Client,
+    ClientContact,
     Contact,
     Contract,
     Cycle,
@@ -440,8 +441,53 @@ def create_heating_data(
     )
     sam_lowry = Client(name="Sam Lowry", invoicing_contact=sam_lowry_contact)
 
-    contacts = [sam_lowry_contact]
+    # Extra contact shared across multiple clients
+    central_services_accountant = Contact(
+        first_name="Jill",
+        last_name="Layton",
+        email="layton@centralservices.com",
+        company="Central Services",
+        address=Address(
+            street="Main Street",
+            number="42",
+            postal_code="55555",
+            city="Somewhere",
+            country="Brazil",
+        ),
+    )
+
+    # Archibald Buttle — wrongly arrested instead of Tuttle
+    archibald_buttle = Contact(
+        first_name="Archibald",
+        last_name="Buttle",
+        email="buttle@centralservices.com",
+        address=Address(
+            street="Shangri-La Towers",
+            number="412",
+            postal_code="55555",
+            city="Somewhere",
+            country="Brazil",
+        ),
+    )
+
+    contacts = [sam_lowry_contact, central_services_accountant, archibald_buttle]
     clients = [central_services, sam_lowry]
+
+    # Many-to-many: contacts ↔ clients with roles
+    client_contacts = [
+        ClientContact(
+            client=central_services, contact=sam_lowry_contact, role="project lead"
+        ),
+        ClientContact(
+            client=central_services,
+            contact=central_services_accountant,
+            role="accountant",
+        ),
+        ClientContact(
+            client=central_services, contact=archibald_buttle, role="shoe repair"
+        ),
+        ClientContact(client=sam_lowry, contact=sam_lowry_contact, role="invoicing"),
+    ]
 
     # -- randomly generated heating-industry clients ---------------------------
 
@@ -453,6 +499,9 @@ def create_heating_data(
         vat_number = f"DE{fake.unique.random_number(digits=9, fix_len=True)}"
         client = Client(name=name, vat_number=vat_number, invoicing_contact=contact)
         clients.append(client)
+        client_contacts.append(
+            ClientContact(client=client, contact=contact, role="invoicing")
+        )
 
     # -- contracts (one per client) --------------------------------------------
 
@@ -527,7 +576,7 @@ def create_heating_data(
         else:
             inv = create_fake_invoice(fake, project=project, user=user)
         invoices.append(inv)
-    return projects, invoices
+    return projects, invoices, client_contacts
 
 
 def create_fake_data(
@@ -668,7 +717,7 @@ def install_demo_data(
         session.refresh(user)
 
     logger.info(f"Creating {n_projects} fake projects...")
-    projects, invoices = create_fake_data(user, n_projects)
+    projects, invoices, client_contacts = create_fake_data(user, n_projects)
 
     # create a fake calendar and add time tracking data from it
     logger.info("Creating a fake calendar...")
@@ -708,6 +757,12 @@ def install_demo_data(
         logger.info("Adding fake projects...")
         for project in projects:
             session.merge(project)
+        session.commit()
+
+        # add client-contact many-to-many associations
+        logger.info("Adding client-contact associations...")
+        for cc in client_contacts:
+            session.merge(cc)
         session.commit()
 
         # render all invoices to PDF while objects are still session-bound

--- a/tuttle/migrations/versions/fbfa8c0c36e4_add_clientcontact_many_to_many_.py
+++ b/tuttle/migrations/versions/fbfa8c0c36e4_add_clientcontact_many_to_many_.py
@@ -1,0 +1,110 @@
+"""add clientcontact many-to-many association table
+
+Revision ID: fbfa8c0c36e4
+Revises: a64c27722470
+Create Date: 2026-06-25 09:00:12.180466
+
+======================================================================
+FROZEN HISTORICAL SNAPSHOT — NOT THE SCHEMA SOURCE OF TRUTH.
+
+The source of truth is tuttle/model.py. This file captures the schema
+DELTA from the previous revision to this point in history. It is
+APPEND-ONLY: once committed, never edit it. To change the schema, edit
+tuttle/model.py and run `just migrate "<msg>"` to ADD a new revision.
+
+Reading this file to learn the current schema is a MISTAKE — it is a
+point-in-time snapshot. Read tuttle/model.py instead.
+======================================================================
+
+MANDATORY REVIEW CHECKLIST before committing this file:
+
+1. RENAMES — autogenerate emits drop_column + add_column for renames,
+   which DESTROYS DATA. If you intended a rename, replace the pair with
+   op.alter_column(<table>, <old>, new_column_name=<new>).
+
+2. NO MODEL IMPORTS — never `from tuttle.model import ...` here.
+   Model classes drift over time; this script must be pinned to the
+   schema at this point in history. For data transformations, declare
+   a local sa.table(...) snapshot with only the columns this revision
+   touches.
+
+3. BATCH MODE — render_as_batch=True rebuilds tables for SQLite. After
+   a batch op on a table with foreign keys, verify integrity inside the
+   migration: op.execute("PRAGMA foreign_key_check").
+
+See tuttle/migrations/README.md.
+----------------------------------------------------------------------
+"""
+# pyright: reportAttributeAccessIssue=false
+# sqlmodel.sql.sqltypes is a submodule resolved at runtime; basedpyright
+# does not statically expose `sql` as an attribute of `sqlmodel`.
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+import sqlmodel.sql.sqltypes  # noqa: F401 — ensures runtime resolution of AutoString
+
+
+revision: str = "fbfa8c0c36e4"
+down_revision: Union[str, Sequence[str], None] = "a64c27722470"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "clientcontact",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("client_id", sa.Integer(), nullable=False),
+        sa.Column("contact_id", sa.Integer(), nullable=False),
+        sa.Column("role", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.ForeignKeyConstraint(["client_id"], ["client.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["contact_id"], ["contact.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Data migration: copy existing invoicing_contact_id → clientcontact rows
+    client = sa.table(
+        "client",
+        sa.column("id", sa.Integer),
+        sa.column("invoicing_contact_id", sa.Integer),
+    )
+    clientcontact = sa.table(
+        "clientcontact",
+        sa.column("client_id", sa.Integer),
+        sa.column("contact_id", sa.Integer),
+        sa.column("role", sa.String),
+    )
+    conn = op.get_bind()
+    rows = conn.execute(
+        sa.select(client.c.id, client.c.invoicing_contact_id).where(
+            client.c.invoicing_contact_id.isnot(None)
+        )
+    ).fetchall()
+    if rows:
+        op.bulk_insert(
+            clientcontact,
+            [
+                {"client_id": r[0], "contact_id": r[1], "role": "invoicing"}
+                for r in rows
+            ],
+        )
+
+
+def downgrade() -> None:
+    """Downgrades are not supported.
+
+    Tuttle is a single-user desktop app. Rolling back schema is destructive
+    (data in dropped columns is lost) and offers nothing over restoring a
+    timestamped backup from ensure_schema()'s pre-upgrade snapshot.
+
+    If you need to iterate on a migration during development:
+    1. Delete this revision file (versions/fbfa8c0c36e4_*.py)
+    2. Run `just reset` to wipe ~/.tuttle
+    3. Edit model.py, run `just migrate` again
+    """
+    raise NotImplementedError(
+        "Downgrades are not supported. Restore from a .bak-<ts> snapshot instead."
+    )

--- a/tuttle/model.py
+++ b/tuttle/model.py
@@ -265,7 +265,11 @@ class Contact(RpcMixin, SQLModel, table=True):
         back_populates="invoicing_contact",
         sa_relationship_kwargs={"lazy": "subquery", "passive_deletes": "all"},
     )
-    # post address
+    # Many-to-many clients via association object
+    client_contacts: List["ClientContact"] = Relationship(
+        back_populates="contact",
+        sa_relationship_kwargs={"lazy": "subquery", "cascade": "all, delete-orphan"},
+    )
 
     # VALIDATORS
     @validator("email")
@@ -312,6 +316,33 @@ class Contact(RpcMixin, SQLModel, table=True):
         )
 
 
+class ClientContact(SQLModel, table=True):
+    """Association between Client and Contact with an optional role.
+
+    Enables many-to-many: a client can have multiple contacts (project lead,
+    accountant, …) and a contact can represent multiple clients.
+    """
+
+    __tablename__ = "clientcontact"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    client_id: int = Field(foreign_key="client.id", ondelete="CASCADE")
+    contact_id: int = Field(foreign_key="contact.id", ondelete="CASCADE")
+    role: Optional[str] = Field(
+        default=None,
+        description="Role of the contact for this client, e.g. 'invoicing', 'project lead'.",
+    )
+
+    client: "Client" = Relationship(
+        back_populates="client_contacts",
+        sa_relationship_kwargs={"lazy": "subquery"},
+    )
+    contact: "Contact" = Relationship(
+        back_populates="client_contacts",
+        sa_relationship_kwargs={"lazy": "subquery"},
+    )
+
+
 class Client(RpcMixin, SQLModel, table=True):
     """A client the freelancer has contracted with.
 
@@ -338,7 +369,7 @@ class Client(RpcMixin, SQLModel, table=True):
         back_populates="clients",
         sa_relationship_kwargs={"lazy": "subquery"},
     )
-    # Client n:1 invoicing Contact (optional)
+    # Client n:1 invoicing Contact (kept for backward compat)
     invoicing_contact_id: Optional[int] = Field(
         default=None, foreign_key="contact.id", ondelete="RESTRICT"
     )
@@ -349,6 +380,11 @@ class Client(RpcMixin, SQLModel, table=True):
     contracts: List["Contract"] = Relationship(
         back_populates="client",
         sa_relationship_kwargs={"lazy": "subquery", "passive_deletes": "all"},
+    )
+    # Many-to-many contacts via association object
+    client_contacts: List["ClientContact"] = Relationship(
+        back_populates="client",
+        sa_relationship_kwargs={"lazy": "subquery", "cascade": "all, delete-orphan"},
     )
 
     @property

--- a/tuttle_tests/test_model.py
+++ b/tuttle_tests/test_model.py
@@ -15,6 +15,7 @@ from tuttle import model, time
 from tuttle.model import (
     Address,
     Client,
+    ClientContact,
     Contact,
     Contract,
     Project,
@@ -188,6 +189,116 @@ class TestClient:
     def test_missing_fields_instantiation(self):
         with pytest.raises(ValidationError):
             Client.validate(dict())
+
+
+class TestClientContact:
+    """Tests for the ClientContact many-to-many association."""
+
+    def test_basic_association(self):
+        """A contact can be linked to a client with a role."""
+        engine = create_engine("sqlite:///")
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as s:
+            contact = Contact(first_name="Sam", last_name="Lowry")
+            client = Client(name="Acme Corp")
+            s.add_all([contact, client])
+            s.commit()
+            s.refresh(contact)
+            s.refresh(client)
+            cid, ctid = client.id, contact.id
+            s.add(ClientContact(client_id=cid, contact_id=ctid, role="invoicing"))
+            s.commit()
+        with Session(engine) as s:
+            rows = s.exec(select(ClientContact)).all()
+            assert len(rows) == 1
+            assert rows[0].role == "invoicing"
+            assert rows[0].client_id == cid
+            assert rows[0].contact_id == ctid
+
+    def test_multiple_contacts_per_client(self):
+        """A client can have multiple contact associations."""
+        engine = create_engine("sqlite:///")
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as s:
+            c1 = Contact(first_name="Alice", last_name="A")
+            c2 = Contact(first_name="Bob", last_name="B")
+            client = Client(name="MultiCo")
+            s.add_all([c1, c2, client])
+            s.commit()
+            s.refresh(c1)
+            s.refresh(c2)
+            s.refresh(client)
+            client_id = client.id
+            s.add(ClientContact(client_id=client.id, contact_id=c1.id, role="lead"))
+            s.add(ClientContact(client_id=client.id, contact_id=c2.id, role="billing"))
+            s.commit()
+        with Session(engine) as s:
+            cl = s.get(Client, client_id)
+            assert len(cl.client_contacts) == 2
+            roles = {a.role for a in cl.client_contacts}
+            assert roles == {"lead", "billing"}
+
+    def test_multiple_clients_per_contact(self):
+        """A contact can represent multiple clients."""
+        engine = create_engine("sqlite:///")
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as s:
+            contact = Contact(first_name="Eve", last_name="E")
+            cl1 = Client(name="Foo Inc")
+            cl2 = Client(name="Bar Ltd")
+            s.add_all([contact, cl1, cl2])
+            s.commit()
+            s.refresh(contact)
+            s.refresh(cl1)
+            s.refresh(cl2)
+            contact_id, cl1_id, cl2_id = contact.id, cl1.id, cl2.id
+            s.add(ClientContact(client_id=cl1_id, contact_id=contact_id, role="CEO"))
+            s.add(ClientContact(client_id=cl2_id, contact_id=contact_id, role="CEO"))
+            s.commit()
+        with Session(engine) as s:
+            ct = s.get(Contact, contact_id)
+            assert len(ct.client_contacts) == 2
+            client_ids = {a.client_id for a in ct.client_contacts}
+            assert client_ids == {cl1_id, cl2_id}
+
+    def test_cascade_delete_client(self):
+        """Deleting a client cascades to its ClientContact rows."""
+        engine = create_engine("sqlite:///")
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as s:
+            contact = Contact(first_name="Z", last_name="Z")
+            client = Client(name="Gone Corp")
+            s.add_all([contact, client])
+            s.commit()
+            s.refresh(contact)
+            s.refresh(client)
+            client_id, contact_id = client.id, contact.id
+            s.add(ClientContact(client_id=client_id, contact_id=contact_id))
+            s.commit()
+        with Session(engine) as s:
+            cl = s.get(Client, client_id)
+            s.delete(cl)
+            s.commit()
+        with Session(engine) as s:
+            assert s.exec(select(ClientContact)).first() is None
+            assert s.get(Contact, contact_id) is not None
+
+    def test_role_is_optional(self):
+        """Association works without a role."""
+        engine = create_engine("sqlite:///")
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as s:
+            contact = Contact(first_name="No", last_name="Role")
+            client = Client(name="Roleless Inc")
+            s.add_all([contact, client])
+            s.commit()
+            s.refresh(contact)
+            s.refresh(client)
+            s.add(ClientContact(client_id=client.id, contact_id=contact.id))
+            s.commit()
+        with Session(engine) as s:
+            row = s.exec(select(ClientContact)).first()
+            assert row.role is None
 
 
 class TestContract:

--- a/ui/src/components/business/ClientsView.tsx
+++ b/ui/src/components/business/ClientsView.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import {
   Building2, Plus, Trash2, Save, X, Search, Mail, MapPin, Users,
-  FileUp, Sparkles, Check, CheckCheck, Loader2,
+  FileUp, Sparkles, Check, CheckCheck, Loader2, UserPlus, Tag,
 } from "lucide-react";
 import { rpc } from "../../api/rpc";
-import { str, entity as subEntity, displayName } from "../../api/entity";
+import { str, num, entity as subEntity, displayName, fullName } from "../../api/entity";
 import type { Entity } from "../../api/types";
 
 type Mode = "view" | "edit" | "create" | "import";
@@ -126,7 +126,13 @@ export function ClientsView() {
     setParsedClients((p) => p.map((c, i) => i === index ? updated : c));
   }
 
-  const filtered = clients.filter((c) => {
+  const sorted = [...clients].sort((a, b) => {
+    const aName = str(a, "name") || "";
+    const bName = str(b, "name") || "";
+    return aName.localeCompare(bName);
+  });
+
+  const filtered = sorted.filter((c) => {
     if (!search) return true;
     const q = search.toLowerCase();
     const name = str(c, "name").toLowerCase();
@@ -181,8 +187,8 @@ export function ClientsView() {
           ) : mode === "edit" && selected ? (
             <ClientForm client={selected} contacts={contacts} onSave={handleSave} onCancel={() => setMode("view")} error={saveError} />
           ) : selected ? (
-            <ClientDetail client={selected} onEdit={() => setMode("edit")}
-              onDelete={() => handleDelete(selected.id)} deleteError={deleteError} />
+            <ClientDetail client={selected} contacts={contacts} onEdit={() => setMode("edit")}
+              onDelete={() => handleDelete(selected.id)} deleteError={deleteError} onReload={load} />
           ) : (
             <div className="flex flex-col items-center justify-center h-full gap-2 text-tertiary">
               <Building2 size={36} strokeWidth={1.2} />
@@ -221,8 +227,10 @@ function ClientRow({ client, isSelected, onSelect }: {
 
 /* ---------- Detail view ---------- */
 
-function ClientDetail({ client, onEdit, onDelete, deleteError }: {
-  client: Entity; onEdit: () => void; onDelete: () => void; deleteError: string | null;
+function ClientDetail({ client, contacts, onEdit, onDelete, deleteError, onReload }: {
+  client: Entity; contacts: Record<string, Entity>;
+  onEdit: () => void; onDelete: () => void; deleteError: string | null;
+  onReload: () => void;
 }) {
   const name = str(client, "name");
   const ic = subEntity(client, "invoicing_contact");
@@ -243,6 +251,37 @@ function ClientDetail({ client, onEdit, onDelete, deleteError }: {
     [str(contactAddr, "postal_code"), str(contactAddr, "city")].filter(Boolean).join(" "),
     str(contactAddr, "country"),
   ].filter(Boolean) : [];
+
+  const [assocs, setAssocs] = useState<Entity[]>([]);
+  const [addingContact, setAddingContact] = useState(false);
+  const [newContactId, setNewContactId] = useState<number | null>(null);
+  const [newRole, setNewRole] = useState("");
+
+  useEffect(() => { loadAssocs(); }, [client.id]);
+
+  async function loadAssocs() {
+    const res = await rpc<Entity[]>("clients.get_contacts_for_client", { client_id: client.id });
+    if (res.ok && res.data) setAssocs(res.data);
+  }
+
+  async function addContact() {
+    if (!newContactId) return;
+    await rpc("clients.add_contact_to_client", {
+      client_id: client.id, contact_id: newContactId, role: newRole || null,
+    });
+    setNewContactId(null);
+    setNewRole("");
+    setAddingContact(false);
+    await loadAssocs();
+  }
+
+  async function removeAssoc(id: number) {
+    await rpc("clients.remove_client_contact", { association_id: id });
+    await loadAssocs();
+  }
+
+  const contactList = Object.values(contacts);
+  const linkedContactIds = new Set(assocs.map((a) => num(a, "contact_id")));
 
   return (
     <div className="p-5 space-y-5">
@@ -306,6 +345,70 @@ function ClientDetail({ client, onEdit, onDelete, deleteError }: {
           )}
         </div>
       )}
+
+      {/* Contacts (many-to-many) */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <div className="text-xs font-semibold uppercase tracking-wider text-secondary">Contacts</div>
+          {!addingContact && (
+            <button onClick={() => setAddingContact(true)}
+              className="flex items-center gap-1 text-xs text-secondary hover:text-primary transition-colors">
+              <UserPlus size={13} /> Add
+            </button>
+          )}
+        </div>
+
+        {assocs.length === 0 && !addingContact && (
+          <div className="text-sm text-tertiary">No contacts linked yet.</div>
+        )}
+
+        {assocs.map((a) => {
+          const ct = contacts[String(num(a, "contact_id"))];
+          const ctName = ct ? displayName(ct) : `Contact #${num(a, "contact_id")}`;
+          const role = str(a, "role");
+          return (
+            <div key={a.id} className="flex items-center gap-3 p-3 rounded-lg bg-bg-card border border-border-subtle group">
+              <span className="text-tertiary"><Users size={14} /></span>
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium truncate">{ctName}</div>
+                {role && (
+                  <div className="flex items-center gap-1 text-xs text-tertiary">
+                    <Tag size={10} /> {role}
+                  </div>
+                )}
+              </div>
+              <button onClick={() => removeAssoc(a.id)}
+                className="opacity-0 group-hover:opacity-100 p-1 rounded text-secondary hover:text-red-400 transition-all"
+                title="Remove contact">
+                <X size={14} />
+              </button>
+            </div>
+          );
+        })}
+
+        {addingContact && (
+          <div className="p-3 rounded-lg bg-bg-card border border-border-subtle space-y-2">
+            <select value={newContactId ?? ""} onChange={(e) => setNewContactId(e.target.value ? Number(e.target.value) : null)}
+              className="w-full px-3 py-2 rounded-md text-sm bg-bg-sidebar text-primary border border-border-subtle outline-none focus:border-accent transition-colors">
+              <option value="">— Select contact —</option>
+              {contactList.filter((c) => !linkedContactIds.has(c.id)).map((c) => (
+                <option key={c.id} value={c.id}>{displayName(c)}</option>
+              ))}
+            </select>
+            <input type="text" placeholder="Role (optional), e.g. project lead, accountant" value={newRole}
+              onChange={(e) => setNewRole(e.target.value)}
+              className="w-full px-3 py-2 rounded-md text-sm bg-bg-sidebar text-primary border border-border-subtle outline-none focus:border-accent transition-colors placeholder:text-muted" />
+            <div className="flex items-center gap-2 justify-end">
+              <button onClick={() => { setAddingContact(false); setNewContactId(null); setNewRole(""); }}
+                className="px-2.5 py-1 rounded text-xs text-secondary hover:text-primary transition-colors">Cancel</button>
+              <button onClick={addContact} disabled={!newContactId}
+                className="px-2.5 py-1 rounded text-xs font-medium text-primary bg-accent/20 hover:bg-accent/30 border border-accent/30 transition-colors disabled:opacity-40">
+                Add
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/ui/src/components/business/ContractsView.tsx
+++ b/ui/src/components/business/ContractsView.tsx
@@ -147,7 +147,13 @@ export function ContractsView() {
     setParsedContracts((p) => p.map((c, i) => i === index ? updated : c));
   }
 
-  const filtered = contracts.filter((c) => {
+  const sorted = [...contracts].sort((a, b) => {
+    const aDate = str(a, "start_date") || str(a, "signature_date") || "";
+    const bDate = str(b, "start_date") || str(b, "signature_date") || "";
+    return bDate.localeCompare(aDate);
+  });
+
+  const filtered = sorted.filter((c) => {
     const status = contractStatus(c);
     if (statusFilter !== "All" && status !== statusFilter) return false;
     if (!search) return true;

--- a/ui/src/components/contacts/ContactsView.tsx
+++ b/ui/src/components/contacts/ContactsView.tsx
@@ -1,16 +1,17 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import {
   Users, Plus, Trash2, Save, X, Mail, Building2, MapPin, Search,
-  FileUp, Sparkles, Check, CheckCheck, Loader2,
+  FileUp, Sparkles, Check, CheckCheck, Loader2, Tag, UserPlus,
 } from "lucide-react";
 import { rpc } from "../../api/rpc";
-import { str, entity as subEntity, fullName, initials, displayName } from "../../api/entity";
+import { str, num, entity as subEntity, fullName, initials, displayName } from "../../api/entity";
 import type { Entity } from "../../api/types";
 
 type Mode = "view" | "edit" | "create" | "import";
 
 export function ContactsView() {
   const [contacts, setContacts] = useState<Entity[]>([]);
+  const [clients, setClients] = useState<Record<string, Entity>>({});
   const [selected, setSelected] = useState<Entity | null>(null);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
@@ -25,7 +26,10 @@ export function ContactsView() {
 
   async function load() {
     setLoading(true);
-    const res = await rpc<Entity[]>("contacts.get_all");
+    const [res, clRes] = await Promise.all([
+      rpc<Entity[]>("contacts.get_all"),
+      rpc<Record<string, Entity>>("contacts.get_all_clients"),
+    ]);
     if (res.ok && res.data) {
       setContacts(res.data);
       const currentId = selectedIdRef.current;
@@ -34,6 +38,7 @@ export function ContactsView() {
         setSelected(updated || null);
       }
     }
+    if (clRes.ok && clRes.data) setClients(clRes.data);
     setLoading(false);
   }
 
@@ -58,7 +63,6 @@ export function ContactsView() {
     const contact: Record<string, unknown> = {
       first_name: data.firstName,
       last_name: data.lastName,
-      company: data.company,
       email: data.email,
       address: {
         street: data.street,
@@ -144,7 +148,13 @@ export function ContactsView() {
     setParsedContacts((prev) => prev.map((c, i) => i === index ? updated : c));
   }
 
-  const filtered = contacts.filter((c) => {
+  const sorted = [...contacts].sort((a, b) => {
+    const aLast = str(a, "last_name") || str(a, "company") || str(a, "name") || "";
+    const bLast = str(b, "last_name") || str(b, "company") || str(b, "name") || "";
+    return aLast.localeCompare(bLast);
+  });
+
+  const filtered = sorted.filter((c) => {
     if (!search) return true;
     const q = search.toLowerCase();
     const name = displayName(c).toLowerCase();
@@ -203,12 +213,12 @@ export function ContactsView() {
               onClose={() => setMode("view")}
             />
           ) : mode === "create" ? (
-            <ContactForm onSave={handleSave} onCancel={() => { setMode("view"); }} />
+            <ContactForm clients={clients} onSave={handleSave} onCancel={() => { setMode("view"); }} />
           ) : mode === "edit" && selected ? (
-            <ContactForm contact={selected} onSave={handleSave}
+            <ContactForm contact={selected} clients={clients} onSave={handleSave}
               onCancel={() => setMode("view")} />
           ) : selected ? (
-            <ContactDetail contact={selected}
+            <ContactDetail contact={selected} clients={clients}
               onEdit={() => setMode("edit")}
               onDelete={() => handleDelete(selected.id)} />
           ) : (
@@ -232,6 +242,7 @@ function ContactRow({ contact, isSelected, onSelect }: {
   const email = str(contact, "email");
   const company = str(contact, "company");
   const ini = initials(contact);
+  const subtitle = company || email;
 
   return (
     <button onClick={onSelect}
@@ -242,11 +253,11 @@ function ContactRow({ contact, isSelected, onSelect }: {
       </div>
       <div className="min-w-0">
         <div className="text-sm font-medium truncate">{name}</div>
-        <div className="flex items-center gap-1.5 text-xs text-tertiary truncate">
-          {company && <span>{company}</span>}
-          {company && email && <span>·</span>}
-          {email && <span>{email}</span>}
-        </div>
+        {subtitle && (
+          <div className="flex items-center gap-1.5 text-xs text-tertiary truncate">
+            <span>{subtitle}</span>
+          </div>
+        )}
       </div>
     </button>
   );
@@ -254,13 +265,13 @@ function ContactRow({ contact, isSelected, onSelect }: {
 
 /* ---------- Detail view ---------- */
 
-function ContactDetail({ contact, onEdit, onDelete }: {
-  contact: Entity; onEdit: () => void; onDelete: () => void;
+function ContactDetail({ contact, clients, onEdit, onDelete }: {
+  contact: Entity; clients: Record<string, Entity>;
+  onEdit: () => void; onDelete: () => void;
 }) {
   const name = displayName(contact);
   const ini = initials(contact);
   const email = str(contact, "email");
-  const company = str(contact, "company");
   const addr = subEntity(contact, "address");
 
   const addrParts = addr ? [
@@ -268,6 +279,38 @@ function ContactDetail({ contact, onEdit, onDelete }: {
     [str(addr, "postal_code"), str(addr, "city")].filter(Boolean).join(" "),
     str(addr, "country"),
   ].filter(Boolean) : [];
+
+  const [assocs, setAssocs] = useState<Entity[]>([]);
+  const [addingClient, setAddingClient] = useState(false);
+  const [newClientId, setNewClientId] = useState<number | null>(null);
+  const [newRole, setNewRole] = useState("");
+
+  useEffect(() => { loadAssocs(); }, [contact.id]);
+
+  async function loadAssocs() {
+    const res = await rpc<Entity[]>("contacts.get_clients_for_contact", { contact_id: contact.id });
+    if (res.ok && res.data) setAssocs(res.data);
+    else setAssocs([]);
+  }
+
+  async function addClient() {
+    if (!newClientId) return;
+    await rpc("contacts.add_client_to_contact", {
+      contact_id: contact.id, client_id: newClientId, role: newRole || null,
+    });
+    setNewClientId(null);
+    setNewRole("");
+    setAddingClient(false);
+    await loadAssocs();
+  }
+
+  async function removeAssoc(id: number) {
+    await rpc("contacts.remove_client_contact", { association_id: id });
+    await loadAssocs();
+  }
+
+  const clientList = Object.values(clients);
+  const linkedClientIds = new Set(assocs.map((a) => num(a, "client_id")));
 
   return (
     <div className="p-5 space-y-5">
@@ -278,12 +321,6 @@ function ContactDetail({ contact, onEdit, onDelete }: {
         </div>
         <div className="flex-1 min-w-0">
           <h1 className="text-lg font-semibold">{name}</h1>
-          {company && str(contact, "first_name") && (
-            <div className="flex items-center gap-1.5 text-sm text-secondary">
-              <Building2 size={14} className="text-tertiary" />
-              <span>{company}</span>
-            </div>
-          )}
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <button onClick={onEdit}
@@ -303,9 +340,6 @@ function ContactDetail({ contact, onEdit, onDelete }: {
         {email && (
           <InfoRow icon={<Mail size={14} />} label="Email" value={email} />
         )}
-        {company && (
-          <InfoRow icon={<Building2 size={14} />} label="Company" value={company} />
-        )}
         {addrParts.length > 0 && (
           <div className="flex items-start gap-3 p-3 rounded-lg bg-bg-card border border-border-subtle">
             <span className="text-tertiary mt-0.5"><MapPin size={14} /></span>
@@ -314,6 +348,69 @@ function ContactDetail({ contact, onEdit, onDelete }: {
               {addrParts.map((line, i) => (
                 <div key={i} className="text-sm">{line}</div>
               ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Companies (many-to-many via ClientContact) */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <div className="text-xs font-semibold uppercase tracking-wider text-secondary">Companies</div>
+          {!addingClient && (
+            <button onClick={() => setAddingClient(true)}
+              className="flex items-center gap-1 text-xs text-secondary hover:text-primary transition-colors">
+              <UserPlus size={13} /> Add
+            </button>
+          )}
+        </div>
+
+        {assocs.length === 0 && !addingClient && (
+          <div className="text-sm text-tertiary">No companies linked yet.</div>
+        )}
+
+        {assocs.map((a) => {
+          const clientName = str(a, "client_name");
+          const role = str(a, "role");
+          return (
+            <div key={a.id} className="flex items-center gap-3 p-3 rounded-lg bg-bg-card border border-border-subtle group">
+              <span className="text-tertiary"><Building2 size={14} /></span>
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium truncate">{clientName || `Client #${num(a, "client_id")}`}</div>
+                {role && (
+                  <div className="flex items-center gap-1 text-xs text-tertiary">
+                    <Tag size={10} /> {role}
+                  </div>
+                )}
+              </div>
+              <button onClick={() => removeAssoc(a.id)}
+                className="opacity-0 group-hover:opacity-100 p-1 rounded text-secondary hover:text-red-400 transition-all"
+                title="Remove company">
+                <X size={14} />
+              </button>
+            </div>
+          );
+        })}
+
+        {addingClient && (
+          <div className="p-3 rounded-lg bg-bg-card border border-border-subtle space-y-2">
+            <select value={newClientId ?? ""} onChange={(e) => setNewClientId(e.target.value ? Number(e.target.value) : null)}
+              className="w-full px-3 py-2 rounded-md text-sm bg-bg-sidebar text-primary border border-border-subtle outline-none focus:border-accent transition-colors">
+              <option value="">— Select client —</option>
+              {clientList.filter((c) => !linkedClientIds.has(c.id)).map((c) => (
+                <option key={c.id} value={c.id}>{str(c, "name")}</option>
+              ))}
+            </select>
+            <input type="text" placeholder="Role (optional), e.g. project lead, accountant" value={newRole}
+              onChange={(e) => setNewRole(e.target.value)}
+              className="w-full px-3 py-2 rounded-md text-sm bg-bg-sidebar text-primary border border-border-subtle outline-none focus:border-accent transition-colors placeholder:text-muted" />
+            <div className="flex items-center gap-2 justify-end">
+              <button onClick={() => { setAddingClient(false); setNewClientId(null); setNewRole(""); }}
+                className="px-2.5 py-1 rounded text-xs text-secondary hover:text-primary transition-colors">Cancel</button>
+              <button onClick={addClient} disabled={!newClientId}
+                className="px-2.5 py-1 rounded text-xs font-medium text-primary bg-accent/20 hover:bg-accent/30 border border-accent/30 transition-colors disabled:opacity-40">
+                Add
+              </button>
             </div>
           </div>
         )}
@@ -339,7 +436,6 @@ function InfoRow({ icon, label, value }: { icon: React.ReactNode; label: string;
 interface ContactFormData {
   firstName: string;
   lastName: string;
-  company: string;
   email: string;
   street: string;
   number: string;
@@ -349,12 +445,11 @@ interface ContactFormData {
 }
 
 function formDataFromEntity(contact?: Entity): ContactFormData {
-  if (!contact) return { firstName: "", lastName: "", company: "", email: "", street: "", number: "", city: "", postalCode: "", country: "" };
+  if (!contact) return { firstName: "", lastName: "", email: "", street: "", number: "", city: "", postalCode: "", country: "" };
   const addr = subEntity(contact, "address");
   return {
     firstName: str(contact, "first_name"),
     lastName: str(contact, "last_name"),
-    company: str(contact, "company"),
     email: str(contact, "email"),
     street: addr ? str(addr, "street") : "",
     number: addr ? str(addr, "number") : "",
@@ -364,12 +459,42 @@ function formDataFromEntity(contact?: Entity): ContactFormData {
   };
 }
 
-function ContactForm({ contact, onSave, onCancel }: {
-  contact?: Entity; onSave: (data: ContactFormData) => void; onCancel: () => void;
+function ContactForm({ contact, clients, onSave, onCancel }: {
+  contact?: Entity; clients: Record<string, Entity>;
+  onSave: (data: ContactFormData) => void; onCancel: () => void;
 }) {
   const [form, setForm] = useState<ContactFormData>(() => formDataFromEntity(contact));
   const [saving, setSaving] = useState(false);
   const isNew = !contact;
+
+  const [assocs, setAssocs] = useState<Entity[]>([]);
+  const [addingClient, setAddingClient] = useState(false);
+  const [newClientId, setNewClientId] = useState<number | null>(null);
+  const [newRole, setNewRole] = useState("");
+
+  useEffect(() => { if (contact) loadAssocs(); }, [contact?.id]);
+
+  async function loadAssocs() {
+    if (!contact) return;
+    const res = await rpc<Entity[]>("contacts.get_clients_for_contact", { contact_id: contact.id });
+    if (res.ok && res.data) setAssocs(res.data);
+  }
+
+  async function addClient() {
+    if (!newClientId || !contact) return;
+    await rpc("contacts.add_client_to_contact", {
+      contact_id: contact.id, client_id: newClientId, role: newRole || null,
+    });
+    setNewClientId(null);
+    setNewRole("");
+    setAddingClient(false);
+    await loadAssocs();
+  }
+
+  async function removeAssoc(id: number) {
+    await rpc("contacts.remove_client_contact", { association_id: id });
+    await loadAssocs();
+  }
 
   function update(field: keyof ContactFormData, value: string) {
     setForm((prev) => ({ ...prev, [field]: value }));
@@ -382,7 +507,9 @@ function ContactForm({ contact, onSave, onCancel }: {
     setSaving(false);
   }
 
-  const hasName = form.firstName.trim() || form.lastName.trim() || form.company.trim();
+  const hasName = form.firstName.trim() || form.lastName.trim();
+  const clientList = Object.values(clients);
+  const linkedClientIds = new Set(assocs.map((a) => num(a, "client_id")));
 
   return (
     <form onSubmit={handleSubmit} className="p-5 space-y-5">
@@ -408,10 +535,7 @@ function ContactForm({ contact, onSave, onCancel }: {
       </Section>
 
       <Section title="Details">
-        <div className="grid grid-cols-2 gap-3">
-          <FormField label="Company" value={form.company} onChange={(v) => update("company", v)} />
-          <FormField label="Email" value={form.email} onChange={(v) => update("email", v)} type="email" />
-        </div>
+        <FormField label="Email" value={form.email} onChange={(v) => update("email", v)} type="email" />
       </Section>
 
       <Section title="Address">
@@ -423,6 +547,66 @@ function ContactForm({ contact, onSave, onCancel }: {
           <FormField label="Country" value={form.country} onChange={(v) => update("country", v)} />
         </div>
       </Section>
+
+      {/* Companies — live-managed via RPC (only for existing contacts) */}
+      {contact && (
+        <Section title="Companies">
+          {assocs.length === 0 && !addingClient && (
+            <div className="text-sm text-tertiary">No companies linked yet.</div>
+          )}
+          <div className="space-y-2">
+            {assocs.map((a) => {
+              const clientName = str(a, "client_name");
+              const role = str(a, "role");
+              return (
+                <div key={a.id} className="flex items-center gap-3 p-3 rounded-lg bg-bg-card border border-border-subtle group">
+                  <span className="text-tertiary"><Building2 size={14} /></span>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium truncate">{clientName || `Client #${num(a, "client_id")}`}</div>
+                    {role && (
+                      <div className="flex items-center gap-1 text-xs text-tertiary">
+                        <Tag size={10} /> {role}
+                      </div>
+                    )}
+                  </div>
+                  <button type="button" onClick={() => removeAssoc(a.id)}
+                    className="opacity-0 group-hover:opacity-100 p-1 rounded text-secondary hover:text-red-400 transition-all"
+                    title="Remove company">
+                    <X size={14} />
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+          {addingClient ? (
+            <div className="p-3 rounded-lg bg-bg-card border border-border-subtle space-y-2 mt-2">
+              <select value={newClientId ?? ""} onChange={(e) => setNewClientId(e.target.value ? Number(e.target.value) : null)}
+                className="w-full px-3 py-2 rounded-md text-sm bg-bg-sidebar text-primary border border-border-subtle outline-none focus:border-accent transition-colors">
+                <option value="">— Select client —</option>
+                {clientList.filter((c) => !linkedClientIds.has(c.id)).map((c) => (
+                  <option key={c.id} value={c.id}>{str(c, "name")}</option>
+                ))}
+              </select>
+              <input type="text" placeholder="Role (optional), e.g. project lead, accountant" value={newRole}
+                onChange={(e) => setNewRole(e.target.value)}
+                className="w-full px-3 py-2 rounded-md text-sm bg-bg-sidebar text-primary border border-border-subtle outline-none focus:border-accent transition-colors placeholder:text-muted" />
+              <div className="flex items-center gap-2 justify-end">
+                <button type="button" onClick={() => { setAddingClient(false); setNewClientId(null); setNewRole(""); }}
+                  className="px-2.5 py-1 rounded text-xs text-secondary hover:text-primary transition-colors">Cancel</button>
+                <button type="button" onClick={addClient} disabled={!newClientId}
+                  className="px-2.5 py-1 rounded text-xs font-medium text-primary bg-accent/20 hover:bg-accent/30 border border-accent/30 transition-colors disabled:opacity-40">
+                  Add
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button type="button" onClick={() => setAddingClient(true)}
+              className="flex items-center gap-1 text-xs text-secondary hover:text-primary transition-colors mt-2">
+              <UserPlus size={13} /> Add company
+            </button>
+          )}
+        </Section>
+      )}
     </form>
   );
 }


### PR DESCRIPTION
- model: introduce ClientContact for linking clients and contacts with roles
- demo: update create_heating_data to include multiple contacts per client
- app: enhance ClientsIntent and ContactsIntent for managing ClientContact associations
- migrations: add migration script for ClientContact table creation and data migration
- tests: implement tests for ClientContact associations and behaviors in test_model.py
- ui: update ClientsView and ContactsView to support contact management