### PR TITLE
feat(timesheet): surface per-entry notes from calendar events in PDF

### DIFF
--- a/.cursor/rules/python-env.mdc
+++ b/.cursor/rules/python-env.mdc
@@ -8,15 +8,16 @@ alwaysApply: true
 This project uses **uv** for dependency management. The virtualenv lives at `.venv/`.
 
 ```bash
-# ✅ Run Python
-.venv/bin/python -m pytest ...
-.venv/bin/python -c "..."
+# ✅ Run Python via uv
+uv run pytest ...
+uv run python -c "..."
 
-# ✅ Or use just (which uses .venv/bin/python internally)
+# ✅ Or use just (which uses uv internally)
 just test
 
-# ❌ NEVER use system python or miniforge
+# ❌ NEVER use system python, miniforge, or direct .venv paths
 python -m pytest ...
+.venv/bin/python -m pytest ...
 ```
 
-When running any Python command (tests, scripts, imports), always prefix with `.venv/bin/python` or use `just`.
+When running any Python command (tests, scripts, imports), always use `uv run` or `just`.

--- a/.cursor/rules/testing-workflow.mdc
+++ b/.cursor/rules/testing-workflow.mdc
@@ -1,0 +1,28 @@
+---
+description: Run tests after every implementation; add tests for new features sparingly but when needed
+alwaysApply: true
+---
+
+# Testing Workflow
+
+## Always run tests after implementation
+
+After making code changes, run the full unit test suite before finishing:
+
+```bash
+uv run pytest --tb=short -q
+```
+
+Do NOT skip this step. Fix any failures introduced by the changes.
+
+## Adding tests for new features
+
+Add tests **sparingly but when needed**:
+
+- ✅ Add a test when a bug is fixed (regression guard)
+- ✅ Add a test when new logic has non-obvious edge cases
+- ✅ Add a test when a function's contract is subtle (e.g. fill-blank-only semantics)
+- ❌ Do NOT add a test for every small cosmetic / template change
+- ❌ Do NOT add tests unless explicitly asked or clearly necessary
+
+Tests live in `tuttle_tests/`. Mirror the module structure (e.g. `tuttle/timetracking.py` → `tuttle_tests/test_timetracking.py`).

--- a/templates/timesheet-anvil/timesheet.css
+++ b/templates/timesheet-anvil/timesheet.css
@@ -111,6 +111,13 @@ table {
 .ts-entries .col-task  { /* flexes to fill */ }
 .ts-entries .col-hours { width: 80px; text-align: right; font-variant-numeric: tabular-nums; }
 
+.col-task-notes {
+  font-size: 0.85em;
+  color: #777;
+  margin-top: 3px;
+  line-height: 1.4;
+}
+
 /* Footer / total row */
 
 .ts-entries tfoot th {

--- a/templates/timesheet-anvil/timesheet.html
+++ b/templates/timesheet-anvil/timesheet.html
@@ -79,7 +79,7 @@
       <tr>
         <th class="col-date">Date</th>
         <th class="col-time">Time</th>
-        <th class="col-task">Task</th>
+        <th class="col-task">Notes</th>
         <th class="col-hours">Hours</th>
       </tr>
     </thead>
@@ -88,7 +88,7 @@
       <tr>
         <td class="col-date">{{ item.begin | date }}</td>
         <td class="col-time">{{ item | time_range }}</td>
-        <td class="col-task">{{ item | clean_title }}</td>
+        <td class="col-task">{{ item | clean_title }}{% if item | clean_notes %}<div class="col-task-notes">{{ item | clean_notes }}</div>{% endif %}</td>
         <td class="col-hours">{{ item.duration | hours_minutes }}</td>
       </tr>
       {% endfor %}

--- a/tuttle/rendering.py
+++ b/tuttle/rendering.py
@@ -331,8 +331,20 @@ def render_timesheet(
             return (item.description or "").strip()
         return title
 
+    def _clean_notes(item) -> str:
+        """Return description only when it adds information beyond the title."""
+        desc = (item.description or "").strip()
+        if not desc:
+            return ""
+        title_raw = (item.title or "").strip()
+        title_clean = _clean_title(item)
+        if desc == title_raw or desc == title_clean:
+            return ""
+        return desc
+
     template_env.filters["time_range"] = _time_range
     template_env.filters["clean_title"] = _clean_title
+    template_env.filters["clean_notes"] = _clean_notes
 
     timesheet_template = template_env.get_template("timesheet.html")
     html = timesheet_template.render(user=user, timesheet=timesheet, style=style)

--- a/tuttle/timetracking.py
+++ b/tuttle/timetracking.py
@@ -79,8 +79,9 @@ def generate_timesheet(
     workday = datetime.timedelta(hours=1) * project.contract.units_per_workday
     ts_table.loc[ts_table["all_day"], "duration"] = workday
     if item_description:
-        # TODO: extract item description from calendar
-        ts_table["description"] = item_description
+        # Only fill rows that have no per-event description from the calendar source.
+        mask = ts_table["description"].isna() | (ts_table["description"] == "")
+        ts_table.loc[mask, "description"] = item_description
 
     period_str = f"{period_start} - {period_end}"
     ts = Timesheet(

--- a/tuttle_tests/test_timetracking.py
+++ b/tuttle_tests/test_timetracking.py
@@ -223,3 +223,36 @@ def test_generate_timesheet_all_day_expansion_day_unit():
     )
 
     assert timesheet.total == datetime.timedelta(hours=8)
+
+
+def test_generate_timesheet_preserves_per_event_descriptions():
+    """item_description fallback must not overwrite per-event calendar descriptions."""
+    tag = "#DescProj"
+    project = _make_project(tag, TimeUnit.hour)
+
+    df = pandas.DataFrame(
+        {
+            "begin": pandas.to_datetime(["2022-03-01 09:00:00", "2022-03-02 09:00:00"]),
+            "end": pandas.to_datetime(["2022-03-01 11:00:00", "2022-03-02 11:00:00"]),
+            "title": ["Meeting", "Deep work"],
+            "tag": [tag, tag],
+            "description": ["Notes from meeting", ""],
+            "all_day": [False, False],
+        }
+    )
+    df["duration"] = df["end"] - df["begin"]
+    df = df.set_index("begin")
+
+    timesheet = timetracking.generate_timesheet(
+        timetracking_data=df,
+        project=project,
+        period_start=datetime.date(2022, 3, 1),
+        period_end=datetime.date(2022, 3, 31),
+        item_description="Fallback description",
+    )
+
+    items = {item.title: item for item in timesheet.items}
+    # Row with an existing description must keep it.
+    assert items["Meeting"].description == "Notes from meeting"
+    # Row with no description gets the fallback.
+    assert items["Deep work"].description == "Fallback description"


### PR DESCRIPTION
Closes #329

## Changes

- **Template**: rename `Task` column to `Notes` in the anvil timesheet PDF template
- **Renderer**: add `clean_notes` Jinja filter — renders `item.description` as sub-text below the title, suppressed when the description duplicates the title
- **Backend**: fix `generate_timesheet()` fill-blank-only logic — per-event calendar descriptions are now preserved; the `item_description` fallback only fills rows that have no description
- **Test**: regression test for the fill-blank-only semantics (`test_generate_timesheet_preserves_per_event_descriptions`)

## Sources supported (unchanged)

- ICS: `event.description`
- macOS EventKit: `event.notes`
- Toggl CSV: `Description` column
