### PR TITLE
UI: consistent toolbar, list layout, and badge components

### DIFF
--- a/ui/src/components/business/ClientsView.tsx
+++ b/ui/src/components/business/ClientsView.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import {
-  Building2, Plus, Trash2, Save, X, Search, Mail, MapPin, Users,
+  Building2, Plus, Trash2, Save, X, Mail, MapPin, Users,
   FileUp, Sparkles, Check, CheckCheck, Loader2, UserPlus, Tag,
 } from "lucide-react";
 import { rpc } from "../../api/rpc";
 import { str, num, entity as subEntity, displayName, fullName } from "../../api/entity";
-import { ToolbarButtonPrimary, ToolbarButtonSecondary } from "../shared/ToolbarButtons";
+import { Toolbar, ToolbarButtonPrimary, ToolbarButtonSecondary, ListDetailLayout, LIST_ROW_PADDING } from "../shared/ToolbarButtons";
 import type { Entity } from "../../api/types";
 
 type Mode = "view" | "edit" | "create" | "import";
@@ -147,36 +147,25 @@ export function ClientsView() {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center gap-2 px-4 py-2 shrink-0 border-b border-border-subtle">
-        <h2 className="text-sm font-semibold">Clients</h2>
-        <ToolbarButtonPrimary icon={<Plus size={13} />} label="New" onClick={startCreate} />
-        <ToolbarButtonSecondary icon={<FileUp size={13} />} label="Import" onClick={startImport} />
-        <div className="relative ml-auto">
-          <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted" />
-          <input type="text" placeholder="Search…" value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="pl-8 pr-3 py-1.5 rounded-md text-sm outline-none w-44 bg-bg-card text-primary border border-border-subtle placeholder:text-muted" />
-        </div>
-      </div>
+      <Toolbar title="Clients"
+        actions={<>
+          <ToolbarButtonPrimary icon={<Plus size={13} />} label="New" onClick={startCreate} />
+          <ToolbarButtonSecondary icon={<FileUp size={13} />} label="Import" onClick={startImport} />
+        </>}
+        search={{ value: search, onChange: setSearch }}
+      />
 
-      <div className="flex flex-1 overflow-hidden">
-        <div className="w-[320px] shrink-0 flex flex-col overflow-hidden border-r border-border-subtle">
-          <div className="flex-1 overflow-y-auto">
-            {filtered.length === 0
-              ? <div className="p-4 text-sm text-center text-tertiary">{search ? "No matches." : "No clients."}</div>
-              : filtered.map((c) => (
-                <ClientRow key={c.id} client={c}
-                  isSelected={selected?.id === c.id && mode !== "create" && mode !== "import"}
-                  onSelect={() => selectClient(c)} />
-              ))}
-          </div>
-          <div className="px-4 py-2 text-xs text-tertiary border-t border-border-subtle">
-            {filtered.length} client{filtered.length !== 1 ? "s" : ""}
-          </div>
-        </div>
-
-        <div className="flex-1 overflow-y-auto">
-          {mode === "import" ? (
+      <ListDetailLayout
+        footer={<>{filtered.length} client{filtered.length !== 1 ? "s" : ""}</>}
+        list={filtered.length === 0
+          ? <div className="p-4 text-sm text-center text-tertiary">{search ? "No matches." : "No clients."}</div>
+          : filtered.map((c) => (
+            <ClientRow key={c.id} client={c}
+              isSelected={selected?.id === c.id && mode !== "create" && mode !== "import"}
+              onSelect={() => selectClient(c)} />
+          ))
+        }
+        detail={mode === "import" ? (
             <DocumentImportPanel
               parsing={parsing} parseError={parseError} parsedClients={parsedClients}
               contacts={contacts}
@@ -195,9 +184,9 @@ export function ClientsView() {
               <Building2 size={36} strokeWidth={1.2} />
               <span className="text-sm">Select a client</span>
             </div>
-          )}
-        </div>
-      </div>
+          )
+        }
+      />
     </div>
   );
 }
@@ -213,7 +202,7 @@ function ClientRow({ client, isSelected, onSelect }: {
 
   return (
     <button onClick={onSelect}
-      className={`w-full text-left px-4 py-3 border-b border-border-subtle transition-colors flex items-center gap-3
+      className={`w-full text-left ${LIST_ROW_PADDING} border-b border-border-subtle transition-colors flex items-center gap-3
         ${isSelected ? "bg-bg-selected" : "hover:bg-bg-hover"}`}>
       <div className="w-9 h-9 rounded-full bg-bg-card flex items-center justify-center text-sm font-semibold text-secondary shrink-0">
         {name.slice(0, 2).toUpperCase()}

--- a/ui/src/components/business/ClientsView.tsx
+++ b/ui/src/components/business/ClientsView.tsx
@@ -5,6 +5,7 @@ import {
 } from "lucide-react";
 import { rpc } from "../../api/rpc";
 import { str, num, entity as subEntity, displayName, fullName } from "../../api/entity";
+import { ToolbarButtonPrimary, ToolbarButtonSecondary } from "../shared/ToolbarButtons";
 import type { Entity } from "../../api/types";
 
 type Mode = "view" | "edit" | "create" | "import";
@@ -148,8 +149,8 @@ export function ClientsView() {
     <div className="flex flex-col h-full">
       <div className="flex items-center gap-2 px-4 py-2 shrink-0 border-b border-border-subtle">
         <h2 className="text-sm font-semibold">Clients</h2>
-        <ToolbarButton icon={<Plus size={15} />} onClick={startCreate} />
-        <ToolbarButton icon={<FileUp size={15} />} label="Import" onClick={startImport} />
+        <ToolbarButtonPrimary icon={<Plus size={13} />} label="New" onClick={startCreate} />
+        <ToolbarButtonSecondary icon={<FileUp size={13} />} label="Import" onClick={startImport} />
         <div className="relative ml-auto">
           <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted" />
           <input type="text" placeholder="Search…" value={search}
@@ -541,18 +542,6 @@ function FormField({ label, value, onChange, type = "text", autoFocus, required,
         className="w-full px-3 py-2 rounded-md text-sm bg-bg-card text-primary border border-border-subtle outline-none
           focus:border-accent transition-colors placeholder:text-muted" />
     </div>
-  );
-}
-
-function ToolbarButton({ icon, label, onClick }: {
-  icon: React.ReactNode; label?: string; onClick: () => void;
-}) {
-  return (
-    <button onClick={onClick}
-      className="flex items-center gap-1.5 px-2 py-1.5 rounded-md text-sm text-secondary hover:text-primary hover:bg-bg-hover transition-colors">
-      {icon}
-      {label && <span>{label}</span>}
-    </button>
   );
 }
 

--- a/ui/src/components/business/ContractsView.tsx
+++ b/ui/src/components/business/ContractsView.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import {
-  FileText, Plus, Trash2, Save, X, Search, DollarSign, Calendar,
+  FileText, Plus, Trash2, Save, X, DollarSign, Calendar,
   FileUp, Sparkles, Check, CheckCheck, Loader2, CheckCircle2,
   FolderKanban, Receipt, ArrowRight,
 } from "lucide-react";
 import { rpc } from "../../api/rpc";
 import { str, num, bool, entity as subEntity, list as entityList, displayName, formatDate } from "../../api/entity";
-import { ToolbarButtonPrimary, ToolbarButtonSecondary } from "../shared/ToolbarButtons";
+import { Toolbar, ToolbarButtonPrimary, ToolbarButtonSecondary, ToolbarFilterGroup, ListDetailLayout, LIST_ROW_PADDING } from "../shared/ToolbarButtons";
+import { StatusBadge } from "../shared/StatusBadge";
 import { useNavigation } from "../shared/NavigationContext";
 import type { Entity } from "../../api/types";
 
@@ -170,44 +171,26 @@ export function ContractsView() {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center gap-2 px-4 py-2 shrink-0 border-b border-border-subtle">
-        <h2 className="text-sm font-semibold">Contracts</h2>
-        <ToolbarButtonPrimary icon={<Plus size={13} />} label="New" onClick={startCreate} />
-        <ToolbarButtonSecondary icon={<FileUp size={13} />} label="Import" onClick={startImport} />
-        <div className="flex items-center gap-1 ml-3">
-          {(["All", "Active", "Upcoming", "Completed"] as StatusFilter[]).map((s) => (
-            <button key={s} onClick={() => setStatusFilter(s)}
-              className={`px-2 py-1 rounded text-xs transition-colors ${statusFilter === s ? "bg-bg-card text-primary font-medium border border-border-subtle" : "text-tertiary hover:text-secondary"}`}>
-              {s}
-            </button>
-          ))}
-        </div>
-        <div className="relative ml-auto">
-          <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted" />
-          <input type="text" placeholder="Search…" value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="pl-8 pr-3 py-1.5 rounded-md text-sm outline-none w-44 bg-bg-card text-primary border border-border-subtle placeholder:text-muted" />
-        </div>
-      </div>
+      <Toolbar title="Contracts"
+        actions={<>
+          <ToolbarButtonPrimary icon={<Plus size={13} />} label="New" onClick={startCreate} />
+          <ToolbarButtonSecondary icon={<FileUp size={13} />} label="Import" onClick={startImport} />
+        </>}
+        center={<ToolbarFilterGroup options={["All", "Active", "Upcoming", "Completed"] as const} value={statusFilter} onChange={setStatusFilter} />}
+        search={{ value: search, onChange: setSearch }}
+      />
 
-      <div className="flex flex-1 overflow-hidden">
-        <div className="w-[320px] shrink-0 flex flex-col overflow-hidden border-r border-border-subtle">
-          <div className="flex-1 overflow-y-auto">
-            {filtered.length === 0
-              ? <div className="p-4 text-sm text-center text-tertiary">{search || statusFilter !== "All" ? "No matches." : "No contracts."}</div>
-              : filtered.map((c) => (
-                <ContractRow key={c.id} contract={c}
-                  isSelected={selected?.id === c.id && mode !== "create" && mode !== "import"}
-                  onSelect={() => selectContract(c)} />
-              ))}
-          </div>
-          <div className="px-4 py-2 text-xs text-tertiary border-t border-border-subtle">
-            {filtered.length} contract{filtered.length !== 1 ? "s" : ""}
-          </div>
-        </div>
-
-        <div className="flex-1 overflow-y-auto">
-          {mode === "import" ? (
+      <ListDetailLayout
+        footer={<>{filtered.length} contract{filtered.length !== 1 ? "s" : ""}</>}
+        list={filtered.length === 0
+          ? <div className="p-4 text-sm text-center text-tertiary">{search || statusFilter !== "All" ? "No matches." : "No contracts."}</div>
+          : filtered.map((c) => (
+            <ContractRow key={c.id} contract={c}
+              isSelected={selected?.id === c.id && mode !== "create" && mode !== "import"}
+              onSelect={() => selectContract(c)} />
+          ))
+        }
+        detail={mode === "import" ? (
             <ContractImportPanel
               parsing={parsing} parseError={parseError} parsedContracts={parsedContracts}
               clients={clients}
@@ -229,9 +212,9 @@ export function ContractsView() {
               <FileText size={36} strokeWidth={1.2} />
               <span className="text-sm">Select a contract</span>
             </div>
-          )}
-        </div>
-      </div>
+          )
+        }
+      />
     </div>
   );
 }
@@ -248,17 +231,13 @@ function ContractRow({ contract, isSelected, onSelect }: {
   const currency = str(contract, "currency") || "EUR";
   const status = contractStatus(contract);
 
-  const statusColors: Record<string, string> = {
-    Active: "text-green-400", Upcoming: "text-blue-400", Completed: "text-tertiary",
-  };
-
   return (
     <button onClick={onSelect}
-      className={`w-full text-left px-4 py-3 border-b border-border-subtle transition-colors
+      className={`w-full text-left ${LIST_ROW_PADDING} border-b border-border-subtle transition-colors
         ${isSelected ? "bg-bg-selected" : "hover:bg-bg-hover"}`}>
       <div className="flex items-center justify-between">
         <div className="text-sm font-medium truncate">{title}</div>
-        <span className={`text-xs ${statusColors[status] || "text-tertiary"}`}>{status}</span>
+        <StatusBadge status={status} />
       </div>
       <div className="flex items-center gap-2 text-xs text-tertiary mt-0.5">
         {clientName && <span>{clientName}</span>}
@@ -285,12 +264,6 @@ function ContractDetail({ contract, onEdit, onDelete, onToggle, deleteError }: {
   const projects = entityList(contract, "projects");
   const invoices = entityList(contract, "invoices");
 
-  const statusColors: Record<string, string> = {
-    Active: "bg-green-500/15 text-green-400 border-green-500/30",
-    Upcoming: "bg-blue-500/15 text-blue-400 border-blue-500/30",
-    Completed: "bg-neutral-500/15 text-neutral-400 border-neutral-500/30",
-  };
-
   const startDate = str(contract, "start_date");
   const endDate = str(contract, "end_date");
   const durationLabel = endDate
@@ -305,9 +278,7 @@ function ContractDetail({ contract, onEdit, onDelete, onToggle, deleteError }: {
           <h1 className="text-lg font-semibold">{title}</h1>
           <div className="text-sm text-secondary mt-0.5">{clientName}</div>
         </div>
-        <span className={`px-2.5 py-1 rounded-full text-xs font-medium border ${statusColors[status] || statusColors.Completed}`}>
-          {status}
-        </span>
+        <StatusBadge status={status} />
       </div>
 
       {/* Actions */}

--- a/ui/src/components/business/ContractsView.tsx
+++ b/ui/src/components/business/ContractsView.tsx
@@ -6,6 +6,7 @@ import {
 } from "lucide-react";
 import { rpc } from "../../api/rpc";
 import { str, num, bool, entity as subEntity, list as entityList, displayName, formatDate } from "../../api/entity";
+import { ToolbarButtonPrimary, ToolbarButtonSecondary } from "../shared/ToolbarButtons";
 import { useNavigation } from "../shared/NavigationContext";
 import type { Entity } from "../../api/types";
 
@@ -171,8 +172,8 @@ export function ContractsView() {
     <div className="flex flex-col h-full">
       <div className="flex items-center gap-2 px-4 py-2 shrink-0 border-b border-border-subtle">
         <h2 className="text-sm font-semibold">Contracts</h2>
-        <ToolbarButton icon={<Plus size={15} />} onClick={startCreate} />
-        <ToolbarButton icon={<FileUp size={15} />} label="Import" onClick={startImport} />
+        <ToolbarButtonPrimary icon={<Plus size={13} />} label="New" onClick={startCreate} />
+        <ToolbarButtonSecondary icon={<FileUp size={13} />} label="Import" onClick={startImport} />
         <div className="flex items-center gap-1 ml-3">
           {(["All", "Active", "Upcoming", "Completed"] as StatusFilter[]).map((s) => (
             <button key={s} onClick={() => setStatusFilter(s)}
@@ -628,18 +629,6 @@ function Section({ title, children }: { title: string; children: React.ReactNode
       <div className="text-xs font-semibold uppercase tracking-wider text-secondary mb-2">{title}</div>
       {children}
     </div>
-  );
-}
-
-function ToolbarButton({ icon, label, onClick }: {
-  icon: React.ReactNode; label?: string; onClick: () => void;
-}) {
-  return (
-    <button onClick={onClick}
-      className="flex items-center gap-1.5 px-2 py-1.5 rounded-md text-sm text-secondary hover:text-primary hover:bg-bg-hover transition-colors">
-      {icon}
-      {label && <span>{label}</span>}
-    </button>
   );
 }
 

--- a/ui/src/components/business/ProjectsView.tsx
+++ b/ui/src/components/business/ProjectsView.tsx
@@ -203,8 +203,12 @@ export function ProjectsView() {
     <div className="flex flex-col h-full">
       <div className="flex items-center gap-2 px-4 py-2 shrink-0 border-b border-border-subtle">
         <h2 className="text-sm font-semibold">Projects</h2>
-        <ToolbarButton icon={<Plus size={15} />} onClick={startCreate} />
-        <ToolbarButton icon={<FileUp size={15} />} label="Import" onClick={startImport} />
+        {viewMode === "list" && (
+          <>
+            <ToolbarButton icon={<Plus size={15} />} onClick={startCreate} />
+            <ToolbarButton icon={<FileUp size={15} />} label="Import" onClick={startImport} />
+          </>
+        )}
         <div className="flex-1" />
         {viewMode === "list" && (
           <div className="flex items-center gap-1">

--- a/ui/src/components/business/ProjectsView.tsx
+++ b/ui/src/components/business/ProjectsView.tsx
@@ -10,6 +10,7 @@ import { StatusBadge } from "../shared/StatusBadge";
 import { ProgressBar } from "../shared/ProgressBar";
 import { ViewModeToggle } from "../shared/ViewModeToggle";
 import { KanbanBoard, useStageStore, type BoardColumn } from "../shared/KanbanBoard";
+import { ToolbarButtonPrimary, ToolbarButtonSecondary } from "../shared/ToolbarButtons";
 import { useNavigation } from "../shared/NavigationContext";
 import type { Entity } from "../../api/types";
 
@@ -205,8 +206,8 @@ export function ProjectsView() {
         <h2 className="text-sm font-semibold">Projects</h2>
         {viewMode === "list" && (
           <>
-            <ToolbarButton icon={<Plus size={15} />} onClick={startCreate} />
-            <ToolbarButton icon={<FileUp size={15} />} label="Import" onClick={startImport} />
+            <ToolbarButtonPrimary icon={<Plus size={13} />} label="New" onClick={startCreate} />
+            <ToolbarButtonSecondary icon={<FileUp size={13} />} label="Import" onClick={startImport} />
           </>
         )}
         <div className="flex-1" />
@@ -574,18 +575,6 @@ function FormField({ label, value, onChange, autoFocus, required }: {
       <input type="text" value={value} onChange={(e) => onChange(e.target.value)} autoFocus={autoFocus} required={required}
         className="w-full px-3 py-2 rounded-md text-sm bg-bg-card text-primary border border-border-subtle outline-none focus:border-accent transition-colors" />
     </div>
-  );
-}
-
-function ToolbarButton({ icon, label, onClick }: {
-  icon: React.ReactNode; label?: string; onClick: () => void;
-}) {
-  return (
-    <button onClick={onClick}
-      className="flex items-center gap-1.5 px-2 py-1.5 rounded-md text-sm text-secondary hover:text-primary hover:bg-bg-hover transition-colors">
-      {icon}
-      {label && <span>{label}</span>}
-    </button>
   );
 }
 

--- a/ui/src/components/business/ProjectsView.tsx
+++ b/ui/src/components/business/ProjectsView.tsx
@@ -1,16 +1,16 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import {
-  FolderKanban, Building2, FileSignature, Calendar, Clock, FileText, Search,
+  FolderKanban, Building2, FileSignature, Calendar, Clock, FileText,
   Plus, Trash2, Save, X, FileUp, Sparkles, Check, CheckCheck, Loader2, CheckCircle2,
   AlertTriangle,
 } from "lucide-react";
 import { rpc } from "../../api/rpc";
 import { str, int, num, bool, entity, dateRange, projectStatus } from "../../api/entity";
-import { StatusBadge } from "../shared/StatusBadge";
+import { StatusBadge, TagBadge } from "../shared/StatusBadge";
 import { ProgressBar } from "../shared/ProgressBar";
 import { ViewModeToggle } from "../shared/ViewModeToggle";
 import { KanbanBoard, useStageStore, type BoardColumn } from "../shared/KanbanBoard";
-import { ToolbarButtonPrimary, ToolbarButtonSecondary } from "../shared/ToolbarButtons";
+import { Toolbar, ToolbarButtonPrimary, ToolbarButtonSecondary, ToolbarFilterGroup, ListDetailLayout, LIST_ROW_PADDING } from "../shared/ToolbarButtons";
 import { useNavigation } from "../shared/NavigationContext";
 import type { Entity } from "../../api/types";
 
@@ -202,70 +202,45 @@ export function ProjectsView() {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center gap-2 px-4 py-2 shrink-0 border-b border-border-subtle">
-        <h2 className="text-sm font-semibold">Projects</h2>
-        {viewMode === "list" && (
-          <>
-            <ToolbarButtonPrimary icon={<Plus size={13} />} label="New" onClick={startCreate} />
-            <ToolbarButtonSecondary icon={<FileUp size={13} />} label="Import" onClick={startImport} />
-          </>
-        )}
-        <div className="flex-1" />
-        {viewMode === "list" && (
-          <div className="flex items-center gap-1">
-            {STATUS_FILTERS.map((s) => {
-              const c = FILTER_COLORS[s];
-              return (
-                <button key={s} onClick={() => setStatusFilter(s)}
-                  className="px-2 py-1 rounded-md text-xs font-medium transition-colors"
-                  style={{
-                    background: statusFilter === s ? `${c}22` : "transparent",
-                    color: statusFilter === s ? c : "var(--color-tertiary)",
-                    border: statusFilter === s ? `1px solid ${c}44` : "1px solid transparent",
-                  }}>{s}</button>
-              );
-            })}
-          </div>
-        )}
-        <ViewModeToggle mode={viewMode} onChange={setViewMode} />
-        <div className="flex-1" />
-        <div className="relative">
-          <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted" />
-          <input type="text" placeholder="Search…" value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="pl-8 pr-3 py-1.5 rounded-md text-sm outline-none w-44 bg-bg-card text-primary border border-border-subtle placeholder:text-muted" />
-        </div>
-      </div>
+      <Toolbar title="Projects"
+        actions={viewMode === "list" ? <>
+          <ToolbarButtonPrimary icon={<Plus size={13} />} label="New" onClick={startCreate} />
+          <ToolbarButtonSecondary icon={<FileUp size={13} />} label="Import" onClick={startImport} />
+        </> : undefined}
+        center={viewMode === "list"
+          ? <ToolbarFilterGroup options={STATUS_FILTERS} value={statusFilter} onChange={setStatusFilter} colors={FILTER_COLORS} />
+          : undefined}
+        right={<ViewModeToggle mode={viewMode} onChange={setViewMode} />}
+        search={{ value: search, onChange: setSearch }}
+      />
 
       {viewMode === "list" ? (
-        <div className="flex flex-1 overflow-hidden">
-          <div className="w-72 shrink-0 flex flex-col border-r border-border-subtle">
-            <div className="flex-1 overflow-y-auto">
-              {filtered.length === 0
-                ? <div className="p-4 text-sm text-center text-tertiary">{search ? "No matches." : "No projects."}</div>
-                : filtered.map((p) => {
-                  const isSelected = selected?.id === p.id && mode === "view";
-                  const isHighlighted = !isSelected && navFilter.contractId != null && num(p, "contract_id") === navFilter.contractId;
-                  return (
-                    <button key={p.id} onClick={() => selectProject(p)}
-                      className={`w-full text-left px-4 py-2.5 border-b transition-colors
-                        ${isSelected ? "bg-bg-selected border-border-subtle" : isHighlighted ? "bg-accent/10 border-accent/30" : "border-border-subtle hover:bg-bg-hover"}`}>
-                      <div className="flex items-center justify-between">
-                        <span className="text-sm font-medium truncate">{str(p, "title")}</span>
-                        <StatusBadge status={projectStatus(p)} />
-                      </div>
-                      <div className="text-xs text-secondary mt-0.5 truncate">{str(p, "tag")}</div>
-                    </button>
-                  );
-                })}
-            </div>
-            <div className="px-4 py-2 text-xs text-tertiary border-t border-border-subtle">
-              {filtered.length} project{filtered.length !== 1 ? "s" : ""}
-            </div>
-          </div>
-
-          <div className="flex-1 overflow-y-auto">
-            {mode === "import" ? (
+        <ListDetailLayout
+          footer={<>{filtered.length} project{filtered.length !== 1 ? "s" : ""}</>}
+          list={filtered.length === 0
+            ? <div className="p-4 text-sm text-center text-tertiary">{search ? "No matches." : "No projects."}</div>
+            : filtered.map((p) => {
+              const isSelected = selected?.id === p.id && mode === "view";
+              const isHighlighted = !isSelected && navFilter.contractId != null && num(p, "contract_id") === navFilter.contractId;
+              return (
+                <button key={p.id} onClick={() => selectProject(p)}
+                  className={`w-full text-left ${LIST_ROW_PADDING} border-b transition-colors
+                    ${isSelected ? "bg-bg-selected border-border-subtle" : isHighlighted ? "bg-accent/10 border-accent/30" : "border-border-subtle hover:bg-bg-hover"}`}>
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-sm font-medium truncate">{str(p, "title")}</span>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <TagBadge tag={str(p, "tag")} />
+                      <StatusBadge status={projectStatus(p)} />
+                    </div>
+                  </div>
+                  {clientName(p) && (
+                    <div className="text-xs text-tertiary mt-0.5 truncate">{clientName(p)}</div>
+                  )}
+                </button>
+              );
+            })
+          }
+          detail={mode === "import" ? (
               <ProjectImportPanel
                 parsing={parsing} parseError={parseError} parsedProjects={parsedProjects}
                 contracts={contractsMap}
@@ -284,7 +259,7 @@ export function ProjectsView() {
                   </div>
                   <div>
                     <h1 className="text-lg font-semibold">{str(selected, "title")}</h1>
-                    <p className="text-xs text-secondary">{str(selected, "tag")}</p>
+                    <TagBadge tag={str(selected, "tag")} className="mt-1" />
                   </div>
                   <StatusBadge status={projectStatus(selected)} className="ml-auto" />
                 </div>
@@ -338,9 +313,9 @@ export function ProjectsView() {
               <div className="flex flex-col items-center justify-center h-full gap-2 text-tertiary">
                 <FolderKanban size={36} strokeWidth={1.2} /><span className="text-sm">Select a project</span>
               </div>
-            )}
-          </div>
-        </div>
+            )
+          }
+        />
       ) : (
         <div className="flex-1 overflow-hidden">
           <KanbanBoard entities={boardFiltered} columns={PROJECT_COLUMNS}
@@ -367,9 +342,7 @@ function ProjectCard({ project, budgetsMap }: { project: Entity; color: string; 
     <div className="space-y-2">
       <div>
         <div className="text-sm font-semibold leading-snug">{str(project, "title")}</div>
-        {str(project, "tag") && (
-          <span className="text-xs font-medium text-tertiary">{str(project, "tag")}</span>
-        )}
+        <TagBadge tag={str(project, "tag")} />
       </div>
       {cName && (
         <div className="flex items-center gap-1.5 text-secondary">

--- a/ui/src/components/contacts/ContactsView.tsx
+++ b/ui/src/components/contacts/ContactsView.tsx
@@ -5,6 +5,7 @@ import {
 } from "lucide-react";
 import { rpc } from "../../api/rpc";
 import { str, num, entity as subEntity, fullName, initials, displayName } from "../../api/entity";
+import { ToolbarButtonPrimary, ToolbarButtonSecondary } from "../shared/ToolbarButtons";
 import type { Entity } from "../../api/types";
 
 type Mode = "view" | "edit" | "create" | "import";
@@ -171,8 +172,8 @@ export function ContactsView() {
       {/* Toolbar */}
       <div className="flex items-center gap-2 px-4 py-2 shrink-0 border-b border-border-subtle">
         <h2 className="text-sm font-semibold">Contacts</h2>
-        <ToolbarButton icon={<Plus size={15} />} onClick={startCreate} />
-        <ToolbarButton icon={<FileUp size={15} />} label="Import" onClick={startImport} />
+        <ToolbarButtonPrimary icon={<Plus size={13} />} label="New" onClick={startCreate} />
+        <ToolbarButtonSecondary icon={<FileUp size={13} />} label="Import" onClick={startImport} />
         <div className="relative ml-auto">
           <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted" />
           <input type="text" placeholder="Search…" value={search}
@@ -630,18 +631,6 @@ function FormField({ label, value, onChange, type = "text", autoFocus }: {
         className="w-full px-3 py-2 rounded-md text-sm bg-bg-card text-primary border border-border-subtle outline-none
           focus:border-accent transition-colors placeholder:text-muted" />
     </div>
-  );
-}
-
-function ToolbarButton({ icon, label, onClick }: {
-  icon: React.ReactNode; label?: string; onClick: () => void;
-}) {
-  return (
-    <button onClick={onClick}
-      className="flex items-center gap-1.5 px-2 py-1.5 rounded-md text-sm text-secondary hover:text-primary hover:bg-bg-hover transition-colors">
-      {icon}
-      {label && <span>{label}</span>}
-    </button>
   );
 }
 

--- a/ui/src/components/contacts/ContactsView.tsx
+++ b/ui/src/components/contacts/ContactsView.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import {
-  Users, Plus, Trash2, Save, X, Mail, Building2, MapPin, Search,
+  Users, Plus, Trash2, Save, X, Mail, Building2, MapPin,
   FileUp, Sparkles, Check, CheckCheck, Loader2, Tag, UserPlus,
 } from "lucide-react";
 import { rpc } from "../../api/rpc";
 import { str, num, entity as subEntity, fullName, initials, displayName } from "../../api/entity";
-import { ToolbarButtonPrimary, ToolbarButtonSecondary } from "../shared/ToolbarButtons";
+import { Toolbar, ToolbarButtonPrimary, ToolbarButtonSecondary, ListDetailLayout, LIST_ROW_PADDING } from "../shared/ToolbarButtons";
 import type { Entity } from "../../api/types";
 
 type Mode = "view" | "edit" | "create" | "import";
@@ -169,39 +169,25 @@ export function ContactsView() {
 
   return (
     <div className="flex flex-col h-full">
-      {/* Toolbar */}
-      <div className="flex items-center gap-2 px-4 py-2 shrink-0 border-b border-border-subtle">
-        <h2 className="text-sm font-semibold">Contacts</h2>
-        <ToolbarButtonPrimary icon={<Plus size={13} />} label="New" onClick={startCreate} />
-        <ToolbarButtonSecondary icon={<FileUp size={13} />} label="Import" onClick={startImport} />
-        <div className="relative ml-auto">
-          <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted" />
-          <input type="text" placeholder="Search…" value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="pl-8 pr-3 py-1.5 rounded-md text-sm outline-none w-44 bg-bg-card text-primary border border-border-subtle placeholder:text-muted" />
-        </div>
-      </div>
+      <Toolbar title="Contacts"
+        actions={<>
+          <ToolbarButtonPrimary icon={<Plus size={13} />} label="New" onClick={startCreate} />
+          <ToolbarButtonSecondary icon={<FileUp size={13} />} label="Import" onClick={startImport} />
+        </>}
+        search={{ value: search, onChange: setSearch }}
+      />
 
-      <div className="flex flex-1 overflow-hidden">
-        {/* List */}
-        <div className="w-[320px] shrink-0 flex flex-col overflow-hidden border-r border-border-subtle">
-          <div className="flex-1 overflow-y-auto">
-            {filtered.length === 0
-              ? <div className="p-4 text-sm text-center text-tertiary">{search ? "No matches." : "No contacts."}</div>
-              : filtered.map((c) => (
-                <ContactRow key={c.id} contact={c}
-                  isSelected={selected?.id === c.id && mode !== "create" && mode !== "import"}
-                  onSelect={() => selectContact(c)} />
-              ))}
-          </div>
-          <div className="px-4 py-2 text-xs text-tertiary border-t border-border-subtle">
-            {filtered.length} contact{filtered.length !== 1 ? "s" : ""}
-          </div>
-        </div>
-
-        {/* Detail / Form / Import */}
-        <div className="flex-1 overflow-y-auto">
-          {mode === "import" ? (
+      <ListDetailLayout
+        footer={<>{filtered.length} contact{filtered.length !== 1 ? "s" : ""}</>}
+        list={filtered.length === 0
+          ? <div className="p-4 text-sm text-center text-tertiary">{search ? "No matches." : "No contacts."}</div>
+          : filtered.map((c) => (
+            <ContactRow key={c.id} contact={c}
+              isSelected={selected?.id === c.id && mode !== "create" && mode !== "import"}
+              onSelect={() => selectContact(c)} />
+          ))
+        }
+        detail={mode === "import" ? (
             <DocumentImportPanel
               parsing={parsing}
               parseError={parseError}
@@ -227,9 +213,9 @@ export function ContactsView() {
               <Users size={36} strokeWidth={1.2} />
               <span className="text-sm">Select a contact</span>
             </div>
-          )}
-        </div>
-      </div>
+          )
+        }
+      />
     </div>
   );
 }
@@ -247,7 +233,7 @@ function ContactRow({ contact, isSelected, onSelect }: {
 
   return (
     <button onClick={onSelect}
-      className={`w-full text-left px-4 py-3 border-b border-border-subtle transition-colors flex items-center gap-3
+      className={`w-full text-left ${LIST_ROW_PADDING} border-b border-border-subtle transition-colors flex items-center gap-3
         ${isSelected ? "bg-bg-selected" : "hover:bg-bg-hover"}`}>
       <div className="w-9 h-9 rounded-full bg-bg-card flex items-center justify-center text-sm font-semibold text-secondary shrink-0">
         {ini}

--- a/ui/src/components/invoicing/InvoicingView.tsx
+++ b/ui/src/components/invoicing/InvoicingView.tsx
@@ -9,6 +9,7 @@ import { str, num, bool, list as entityList, formatDate, invoiceStatus, deepStr,
 import { StatusBadge } from "../shared/StatusBadge";
 import { ViewModeToggle } from "../shared/ViewModeToggle";
 import { KanbanBoard, useStageStore, type BoardColumn } from "../shared/KanbanBoard";
+import { ToolbarButtonPrimary } from "../shared/ToolbarButtons";
 import { useNavigation } from "../shared/NavigationContext";
 import type { Entity } from "../../api/types";
 
@@ -133,10 +134,7 @@ export function InvoicingView() {
       <div className="flex items-center gap-2 px-4 py-2 shrink-0 border-b border-border-subtle">
         <h2 className="text-sm font-semibold">Invoicing</h2>
         {viewMode === "list" && (
-          <button onClick={() => setCreateOpen(true)}
-            className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-accent text-white hover:bg-accent/90 transition-colors">
-            <Plus size={13} /> Create Invoice
-          </button>
+          <ToolbarButtonPrimary icon={<Plus size={13} />} label="Create Invoice" onClick={() => setCreateOpen(true)} />
         )}
         <div className="flex-1" />
         {viewMode === "list" && (

--- a/ui/src/components/invoicing/InvoicingView.tsx
+++ b/ui/src/components/invoicing/InvoicingView.tsx
@@ -132,10 +132,12 @@ export function InvoicingView() {
       {/* Toolbar */}
       <div className="flex items-center gap-2 px-4 py-2 shrink-0 border-b border-border-subtle">
         <h2 className="text-sm font-semibold">Invoicing</h2>
-        <button onClick={() => setCreateOpen(true)}
-          className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-accent text-white hover:bg-accent/90 transition-colors">
-          <Plus size={13} /> Create Invoice
-        </button>
+        {viewMode === "list" && (
+          <button onClick={() => setCreateOpen(true)}
+            className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-accent text-white hover:bg-accent/90 transition-colors">
+            <Plus size={13} /> Create Invoice
+          </button>
+        )}
         <div className="flex-1" />
         {viewMode === "list" && (
           <div className="flex items-center gap-1">

--- a/ui/src/components/invoicing/InvoicingView.tsx
+++ b/ui/src/components/invoicing/InvoicingView.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
 import {
   FileText, Send, CheckCircle, XCircle, Mail, Trash2,
-  Building2, FolderKanban, Calendar, Banknote, Eye, Search,
-  Plus, Clock, AlertTriangle, ChevronLeft, ChevronRight,
+  Building2, FolderKanban, Calendar, Banknote, Eye,
+  Plus, Clock, AlertTriangle, ChevronLeft, ChevronRight, Search,
 } from "lucide-react";
 import { rpc, readFileAsDataURL } from "../../api/rpc";
 import { str, num, bool, list as entityList, formatDate, invoiceStatus, deepStr, isReminder, reminderLevel } from "../../api/entity";
 import { StatusBadge } from "../shared/StatusBadge";
 import { ViewModeToggle } from "../shared/ViewModeToggle";
 import { KanbanBoard, useStageStore, type BoardColumn } from "../shared/KanbanBoard";
-import { ToolbarButtonPrimary } from "../shared/ToolbarButtons";
+import { Toolbar, ToolbarButtonPrimary, ToolbarFilterGroup, ListDetailLayout, LIST_ROW_PADDING } from "../shared/ToolbarButtons";
 import { useNavigation } from "../shared/NavigationContext";
 import type { Entity } from "../../api/types";
 
@@ -130,38 +130,16 @@ export function InvoicingView() {
 
   return (
     <div className="flex flex-col h-full">
-      {/* Toolbar */}
-      <div className="flex items-center gap-2 px-4 py-2 shrink-0 border-b border-border-subtle">
-        <h2 className="text-sm font-semibold">Invoicing</h2>
-        {viewMode === "list" && (
-          <ToolbarButtonPrimary icon={<Plus size={13} />} label="Create Invoice" onClick={() => setCreateOpen(true)} />
-        )}
-        <div className="flex-1" />
-        {viewMode === "list" && (
-          <div className="flex items-center gap-1">
-            {STATUS_FILTERS.map((s) => {
-              const c = FILTER_COLORS[s];
-              return (
-                <button key={s} onClick={() => setStatusFilter(s)}
-                  className="px-2 py-1 rounded-md text-xs font-medium transition-colors"
-                  style={{
-                    background: statusFilter === s ? `${c}22` : "transparent",
-                    color: statusFilter === s ? c : "var(--color-tertiary)",
-                    border: statusFilter === s ? `1px solid ${c}44` : "1px solid transparent",
-                  }}>{s}</button>
-              );
-            })}
-          </div>
-        )}
-        <ViewModeToggle mode={viewMode} onChange={setViewMode} />
-        <div className="flex-1" />
-        <div className="relative">
-          <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted" />
-          <input type="text" placeholder="Search…" value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="pl-8 pr-3 py-1.5 rounded-md text-sm outline-none w-44 bg-bg-card text-primary border border-border-subtle placeholder:text-muted" />
-        </div>
-      </div>
+      <Toolbar title="Invoicing"
+        actions={viewMode === "list"
+          ? <ToolbarButtonPrimary icon={<Plus size={13} />} label="Create Invoice" onClick={() => setCreateOpen(true)} />
+          : undefined}
+        center={viewMode === "list"
+          ? <ToolbarFilterGroup options={STATUS_FILTERS} value={statusFilter} onChange={setStatusFilter} colors={FILTER_COLORS} />
+          : undefined}
+        right={<ViewModeToggle mode={viewMode} onChange={setViewMode} />}
+        search={{ value: search, onChange: setSearch }}
+      />
 
       {renderWarning && (
         <div className="mx-4 mt-2 flex items-center gap-2 px-3 py-2 rounded-md text-xs text-amber-300 bg-amber-500/10 border border-amber-500/30">
@@ -172,37 +150,29 @@ export function InvoicingView() {
       )}
 
       {viewMode === "list" ? (
-        <div className="flex flex-1 overflow-hidden">
-          {/* List */}
-          <div className="w-[420px] shrink-0 flex flex-col overflow-hidden border-r border-border-subtle">
-            <div className="flex-1 overflow-y-auto">
-              {chains.length === 0
-                ? <div className="p-4 text-sm text-center text-tertiary">{search ? "No matches." : "No invoices."}</div>
-                : chains.map((chain) => {
-                  const inv = chain.root;
-                  const isSelected = selected?.id === inv.id;
-                  const isHighlighted = !isSelected && (inv.id === newlyCreatedId || (navFilter.contractId != null && num(inv, "contract_id") === navFilter.contractId));
-                  return (
-                    <div key={inv.id}>
-                      <InvoiceRow invoice={inv} isSelected={isSelected} isHighlighted={isHighlighted}
-                        reminderCount={chain.reminders.length}
-                        onSelect={() => { setNewlyCreatedId(null); setSelected(inv); }} />
-                      {chain.reminders.map((rem) => {
-                        const remSelected = selected?.id === rem.id;
-                        return <ReminderRow key={rem.id} invoice={rem} isSelected={remSelected}
-                          onSelect={() => { setNewlyCreatedId(null); setSelected(rem); }} />;
-                      })}
-                    </div>
-                  );
-                })}
-            </div>
-            <div className="px-4 py-2 text-xs text-tertiary border-t border-border-subtle">
-              {filtered.length} invoice{filtered.length !== 1 ? "s" : ""}
-            </div>
-          </div>
-          {/* Detail */}
-          <div className="flex-1 overflow-y-auto">
-            {selected ? (
+        <ListDetailLayout
+          footer={<>{filtered.length} invoice{filtered.length !== 1 ? "s" : ""}</>}
+          list={chains.length === 0
+            ? <div className="p-4 text-sm text-center text-tertiary">{search ? "No matches." : "No invoices."}</div>
+            : chains.map((chain) => {
+              const inv = chain.root;
+              const isSelected = selected?.id === inv.id;
+              const isHighlighted = !isSelected && (inv.id === newlyCreatedId || (navFilter.contractId != null && num(inv, "contract_id") === navFilter.contractId));
+              return (
+                <div key={inv.id}>
+                  <InvoiceRow invoice={inv} isSelected={isSelected} isHighlighted={isHighlighted}
+                    reminderCount={chain.reminders.length}
+                    onSelect={() => { setNewlyCreatedId(null); setSelected(inv); }} />
+                  {chain.reminders.map((rem) => {
+                    const remSelected = selected?.id === rem.id;
+                    return <ReminderRow key={rem.id} invoice={rem} isSelected={remSelected}
+                      onSelect={() => { setNewlyCreatedId(null); setSelected(rem); }} />;
+                  })}
+                </div>
+              );
+            })
+          }
+          detail={selected ? (
               <InvoiceDetail invoice={selected} allInvoices={invoices}
                 onToggleSent={() => toggleSent(selected.id)}
                 onTogglePaid={() => togglePaid(selected.id)} onToggleCancelled={() => toggleCancelled(selected.id)}
@@ -215,9 +185,9 @@ export function InvoicingView() {
               <div className="flex flex-col items-center justify-center h-full gap-2 text-tertiary">
                 <FileText size={36} strokeWidth={1.2} /><span className="text-sm">Select an invoice</span>
               </div>
-            )}
-          </div>
-        </div>
+            )
+          }
+        />
       ) : (
         <div className="flex-1 overflow-hidden">
           <KanbanBoard entities={boardRoots} columns={INVOICE_COLUMNS}
@@ -580,7 +550,7 @@ function InvoiceRow({ invoice, isSelected, isHighlighted, reminderCount, onSelec
   const status = invoiceStatus(invoice);
   return (
     <button onClick={onSelect}
-      className={`w-full text-left px-4 py-3 border-b transition-colors
+      className={`w-full text-left ${LIST_ROW_PADDING} border-b transition-colors
         ${isSelected ? "bg-bg-selected border-border-subtle" : isHighlighted ? "bg-accent/10 border-accent/30" : "border-border-subtle hover:bg-bg-hover"}`}>
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 min-w-0">

--- a/ui/src/components/shared/StatusBadge.tsx
+++ b/ui/src/components/shared/StatusBadge.tsx
@@ -1,3 +1,5 @@
+/* ── Status badge ──────────────────────────────────────────────────────── */
+
 const STATUS_COLORS: Record<string, string> = {
   active: "#34d399", upcoming: "#60a5fa", completed: "#a0a0a0",
   draft: "#a0a0a0", sent: "#60a5fa", paid: "#34d399",
@@ -5,14 +7,23 @@ const STATUS_COLORS: Record<string, string> = {
   lead: "#c084fc", offer: "#fb923c",
 };
 
-type Props = { status: string; className?: string };
-
-export function StatusBadge({ status, className = "" }: Props) {
+export function StatusBadge({ status, className = "" }: { status: string; className?: string }) {
   const color = STATUS_COLORS[status.toLowerCase()] || "#a0a0a0";
   return (
     <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${className}`}
       style={{ background: `${color}1a`, color, border: `1px solid ${color}33` }}>
       {status}
+    </span>
+  );
+}
+
+/* ── Tag badge ─────────────────────────────────────────────────────────── */
+
+export function TagBadge({ tag, className = "" }: { tag: string; className?: string }) {
+  if (!tag) return null;
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium bg-bg-hover text-tertiary border border-border-subtle ${className}`}>
+      {tag}
     </span>
   );
 }

--- a/ui/src/components/shared/ToolbarButtons.tsx
+++ b/ui/src/components/shared/ToolbarButtons.tsx
@@ -1,11 +1,75 @@
+import { Search } from "lucide-react";
 import type { ReactNode } from "react";
+
+/* ── Layout constants ─────────────────────────────────────────────────── */
+
+export const LIST_PANEL_WIDTH = "w-[480px]";
+export const LIST_ROW_PADDING = "px-4 py-3.5";
+
+/* ── List / Detail split layout ───────────────────────────────────────── */
+
+export function ListDetailLayout({ list, detail, footer }: {
+  list: ReactNode;
+  detail: ReactNode;
+  footer?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-1 overflow-hidden">
+      <div className={`${LIST_PANEL_WIDTH} shrink-0 flex flex-col overflow-hidden border-r border-border-subtle`}>
+        <div className="flex-1 overflow-y-auto">{list}</div>
+        {footer && (
+          <div className={`${LIST_ROW_PADDING} text-xs text-tertiary border-t border-border-subtle`}>{footer}</div>
+        )}
+      </div>
+      <div className="flex-1 overflow-y-auto">{detail}</div>
+    </div>
+  );
+}
+
+/*
+ * Toolbar — consistent top bar for all list/entity views.
+ *
+ * Layout: Title | actions | ―flex― | center | ―flex― | right | Search
+ *
+ * - `title`   – view name (always visible, left-anchored)
+ * - `actions` – primary/secondary buttons next to the title
+ * - `center`  – filters or other centered content (optional)
+ * - `right`   – view-mode toggle or extra controls before search (optional)
+ * - `search`  – search state; omit to hide the search field
+ */
+export function Toolbar({ title, actions, center, right, search }: {
+  title: string;
+  actions?: ReactNode;
+  center?: ReactNode;
+  right?: ReactNode;
+  search?: { value: string; onChange: (v: string) => void; placeholder?: string };
+}) {
+  return (
+    <div className="flex items-center gap-2 px-4 py-2 shrink-0 border-b border-border-subtle">
+      <h2 className="text-sm font-semibold mr-1">{title}</h2>
+      {actions}
+      <div className="flex-1" />
+      {center}
+      {center && <div className="flex-1" />}
+      {right}
+      {search && (
+        <div className="relative">
+          <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted" />
+          <input type="text" placeholder={search.placeholder ?? "Search…"} value={search.value}
+            onChange={(e) => search.onChange(e.target.value)}
+            className="pl-8 pr-3 py-1.5 rounded-md text-sm outline-none w-44 bg-bg-card text-primary border border-border-subtle placeholder:text-muted" />
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function ToolbarButtonPrimary({ icon, label, onClick }: {
   icon: ReactNode; label: string; onClick: () => void;
 }) {
   return (
     <button onClick={onClick}
-      className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-accent text-white hover:bg-accent/90 transition-colors">
+      className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-accent text-white hover:bg-accent/80 hover:shadow-sm active:scale-[0.97] transition-all">
       {icon}
       <span>{label}</span>
     </button>
@@ -17,9 +81,38 @@ export function ToolbarButtonSecondary({ icon, label, onClick }: {
 }) {
   return (
     <button onClick={onClick}
-      className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium text-secondary hover:text-primary border border-border-subtle hover:bg-bg-hover transition-colors">
+      className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium text-secondary hover:text-primary border border-border-subtle hover:bg-bg-hover hover:border-border active:scale-[0.97] transition-all">
       {icon}
       <span>{label}</span>
     </button>
+  );
+}
+
+export function ToolbarFilterGroup<T extends string>({ options, value, onChange, colors, icons, labels }: {
+  options: readonly T[];
+  value: T;
+  onChange: (v: T) => void;
+  colors?: Record<string, string>;
+  icons?: Record<string, ReactNode>;
+  labels?: Record<string, string>;
+}) {
+  return (
+    <div className="flex items-center gap-0.5 rounded-lg bg-bg-card border border-border-subtle p-0.5">
+      {options.map((opt) => {
+        const active = value === opt;
+        const color = colors?.[opt];
+        const icon = icons?.[opt];
+        return (
+          <button key={opt} onClick={() => onChange(opt)}
+            className="flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium transition-colors"
+            style={active
+              ? { background: color ? `${color}22` : "var(--color-bg-hover)", color: color || "var(--color-primary)", border: color ? `1px solid ${color}44` : "1px solid var(--color-border-subtle)" }
+              : { background: "transparent", color: "var(--color-tertiary)", border: "1px solid transparent" }
+            }>
+            {icon}{labels?.[opt] ?? opt}
+          </button>
+        );
+      })}
+    </div>
   );
 }

--- a/ui/src/components/shared/ToolbarButtons.tsx
+++ b/ui/src/components/shared/ToolbarButtons.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+export function ToolbarButtonPrimary({ icon, label, onClick }: {
+  icon: ReactNode; label: string; onClick: () => void;
+}) {
+  return (
+    <button onClick={onClick}
+      className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-accent text-white hover:bg-accent/90 transition-colors">
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+export function ToolbarButtonSecondary({ icon, label, onClick }: {
+  icon: ReactNode; label: string; onClick: () => void;
+}) {
+  return (
+    <button onClick={onClick}
+      className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium text-secondary hover:text-primary border border-border-subtle hover:bg-bg-hover transition-colors">
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/ui/src/components/timeline/TimelineView.tsx
+++ b/ui/src/components/timeline/TimelineView.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState, useMemo } from "react";
 import {
   FileText, FileSignature, FolderKanban, Flag,
-  ListFilter, Search, CalendarDays,
+  ListFilter, CalendarDays,
 } from "lucide-react";
 import { rpc } from "../../api/rpc";
+import { Toolbar, ToolbarFilterGroup } from "../shared/ToolbarButtons";
 import type { Entity } from "../../api/types";
 import { str, bool } from "../../api/entity";
 
@@ -18,10 +19,18 @@ const CATEGORIES: { id: Category; label: string; icon: typeof FileText }[] = [
 ];
 
 const CATEGORY_COLORS: Record<string, string> = {
+  all:      "var(--color-status-info)",
   invoice:  "var(--color-status-info)",
   contract: "var(--color-status-success)",
   project:  "var(--color-status-warning)",
   goal:     "#BF5AF2",
+};
+
+const FILTER_OPTIONS = ["all", "invoice", "contract", "project", "goal"] as const;
+const FILTER_LABELS: Record<string, string> = { all: "All", invoice: "Invoices", contract: "Contracts", project: "Projects", goal: "Goals" };
+const FILTER_ICONS: Record<string, React.ReactNode> = {
+  all: <ListFilter size={12} />, invoice: <FileText size={12} />,
+  contract: <FileSignature size={12} />, project: <FolderKanban size={12} />, goal: <Flag size={12} />,
 };
 
 function dotColor(event: Entity): string {
@@ -120,49 +129,26 @@ export function TimelineView() {
 
   if (!events.length) {
     return (
-      <div className="flex flex-col items-center justify-center h-full gap-3 text-secondary">
-        <CalendarDays size={40} strokeWidth={1.2} />
-        <span className="text-lg font-medium">No Events Yet</span>
-        <span className="text-sm text-muted">Create invoices, contracts, or projects to see them here.</span>
+      <div className="flex flex-col h-full">
+        <Toolbar title="Timeline" />
+        <div className="flex flex-col items-center justify-center flex-1 gap-3 text-secondary">
+          <CalendarDays size={40} strokeWidth={1.2} />
+          <span className="text-lg font-medium">No Events Yet</span>
+          <span className="text-sm text-muted">Create invoices, contracts, or projects to see them here.</span>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="p-6 max-w-3xl">
-      {/* Search + Filter bar */}
-      <div className="flex items-center gap-3 mb-5">
-        <div className="relative flex-1 max-w-xs">
-          <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted" />
-          <input
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="Search events…"
-            className="w-full pl-8 pr-3 py-1.5 rounded-md border border-border-subtle bg-bg-content text-sm text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent"
-          />
-        </div>
-        <div className="flex gap-1.5">
-          {CATEGORIES.map((cat) => {
-            const active = activeFilter === cat.id;
-            const color = cat.id === "all" ? "var(--color-status-info)" : CATEGORY_COLORS[cat.id];
-            return (
-              <button
-                key={cat.id}
-                onClick={() => setActiveFilter(cat.id)}
-                className="flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold border transition-colors"
-                style={{
-                  borderColor: color,
-                  backgroundColor: active ? color : "transparent",
-                  color: active ? "#fff" : color,
-                }}
-              >
-                <cat.icon size={12} />
-                {cat.label}
-              </button>
-            );
-          })}
-        </div>
-      </div>
+    <div className="flex flex-col h-full">
+      <Toolbar title="Timeline"
+        center={<ToolbarFilterGroup options={FILTER_OPTIONS} value={activeFilter} onChange={setActiveFilter}
+          colors={CATEGORY_COLORS} icons={FILTER_ICONS} labels={FILTER_LABELS} />}
+        search={{ value: searchQuery, onChange: setSearchQuery, placeholder: "Search events…" }}
+      />
+
+      <div className="flex-1 overflow-y-auto p-6 max-w-3xl">
 
       {/* Filtered-empty state */}
       {!filtered.length && (
@@ -199,6 +185,7 @@ export function TimelineView() {
             </div>
           ))}
       </div>
+    </div>
     </div>
   );
 }

--- a/ui/src/components/timetracking/TimeTrackingView.tsx
+++ b/ui/src/components/timetracking/TimeTrackingView.tsx
@@ -4,6 +4,7 @@ import {
   FolderKanban, Trash2, MonitorSmartphone, Settings, RefreshCw,
 } from "lucide-react";
 import { rpc } from "../../api/rpc";
+import { Toolbar, ToolbarButtonSecondary } from "../shared/ToolbarButtons";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -217,45 +218,18 @@ export function TimeTrackingView() {
 
   return (
     <div className="flex flex-col h-full">
-      {/* Toolbar */}
-      <div className="flex items-center gap-2 px-4 py-2 shrink-0 border-b border-border-subtle">
-        <h2 className="text-sm font-semibold">Time Tracking</h2>
-        <div className="flex-1" />
-        {monthHasEvents && (
-          <div className="flex items-center gap-3 text-xs text-primary">
-            <div className="flex items-center gap-1.5">
-              <Clock size={13} className="text-secondary" />
-              <span className="tabular-nums font-bold">{calData!.summary.total_hours}h</span>
-              <span className="text-secondary">across</span>
-              <span className="tabular-nums font-bold">{calData!.summary.total_events}</span>
-              <span className="text-secondary">events</span>
-            </div>
-            {calData!.summary.planned_hours > 0 && (
-              <div className="flex items-center gap-1.5 text-blue-400">
-                <span className="text-secondary">·</span>
-                <span className="tabular-nums font-bold">{calData!.summary.planned_hours}h</span>
-                <span className="text-blue-400/70">planned</span>
-              </div>
-            )}
-          </div>
-        )}
-        {hasAnyData && (
-          <>
-            <button onClick={syncCalendar} disabled={syncing}
-              className="flex items-center gap-1 px-2 py-1 rounded-md text-xs text-secondary hover:text-primary hover:bg-bg-hover transition-colors disabled:opacity-50"
-              title="Re-sync with calendar">
-              <RefreshCw size={13} className={syncing ? "animate-spin" : ""} />
-              <span>{syncing ? "Syncing…" : "Sync"}</span>
-            </button>
-            <button onClick={clearData}
-              className="flex items-center gap-1 px-2 py-1 rounded-md text-xs text-muted hover:text-red-400 hover:bg-bg-hover transition-colors"
-              title="Clear imported data and choose a different source">
-              <Trash2 size={13} />
-              <span>Change source</span>
-            </button>
-          </>
-        )}
-      </div>
+      <Toolbar title="Time Tracking"
+        actions={hasAnyData ? <>
+          <ToolbarButtonSecondary
+            icon={<RefreshCw size={13} className={syncing ? "animate-spin" : ""} />}
+            label={syncing ? "Syncing…" : "Sync"}
+            onClick={syncCalendar} />
+          <ToolbarButtonSecondary
+            icon={<Trash2 size={13} />}
+            label="Change source"
+            onClick={clearData} />
+        </> : undefined}
+      />
 
       <div className="flex flex-1 overflow-hidden">
         {/* Main area */}
@@ -371,6 +345,11 @@ export function TimeTrackingView() {
               <div className="text-[11px] font-bold uppercase tracking-wider text-primary mb-1">Total</div>
               <div className="text-xl font-bold tabular-nums text-primary">{calData!.summary.total_hours}h</div>
               <div className="text-xs text-secondary">{calData!.summary.total_events} events</div>
+              {calData!.summary.planned_hours > 0 && (
+                <div className="text-xs text-blue-400 mt-1">
+                  {calData!.summary.planned_hours}h planned
+                </div>
+              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary

Introduces centralized layout components to replace ad-hoc, per-view styling across the UI:

- **`Toolbar`** — shared top bar with consistent slot layout (title, actions, filters, view toggle, search) used by all 7 views
- **`ToolbarButtonPrimary` / `ToolbarButtonSecondary`** — unified button styles with clear hover/active feedback
- **`ToolbarFilterGroup`** — segmented filter control with icon/label/color support
- **`ListDetailLayout`** — single component owning the list/detail split (panel width, row padding, scroll, footer), replacing 5 different inline implementations
- **`TagBadge`** — centralized tag rendering as rounded pill, consistent everywhere tags appear
- **`StatusBadge`** — now the sole status renderer (removed duplicate inline definitions from Contracts)

All layout constants (`LIST_PANEL_WIDTH`, `LIST_ROW_PADDING`) are defined once and consumed by every view.

## What changed per view

| View | Changes |
|------|---------|
| Projects | Toolbar, ListDetailLayout, TagBadge, hide create buttons in Kanban mode |
| Contracts | Toolbar, ListDetailLayout, StatusBadge (was inline), ToolbarFilterGroup |
| Clients | Toolbar, ListDetailLayout |
| Contacts | Toolbar, ListDetailLayout |
| Invoicing | Toolbar, ListDetailLayout, hide create button in board mode |
| Time Tracking | Toolbar, removed summary data from toolbar → sidebar |
| Timeline | Toolbar with icon/label filters, centralized search placement |

## Test plan

- [x] `tsc --noEmit` passes
- [x] `pytest` passes (304 tests)
- [x] Visual check: toolbar layout consistent across all views
- [x] Visual check: list panel width identical in Projects, Contracts, Clients, Contacts, Invoicing
- [x] Visual check: tags render as pills in list, detail, and kanban card
- [x] Visual check: status badges consistent between Projects and Contracts
- [x] Hover feedback visible on all toolbar buttons


