### PR TITLE
Fix German VAT column header and add fixed_price unit label

### DIFF
--- a/tuttle/rendering.py
+++ b/tuttle/rendering.py
@@ -63,7 +63,7 @@ INVOICE_LABELS = {
         "qty": "Menge",
         "unit": "Einheit",
         "unit_price": "Einzelpreis",
-        "vat": "MwSt.",
+        "vat": "USt.",
         "subtotal": "Zwischensumme",
         "total_due": "Gesamtbetrag",
         "payment": "Zahlung",
@@ -79,6 +79,7 @@ INVOICE_LABELS = {
         "units": {
             "hour": ("Stunde", "Stunden"),
             "day": ("Tag", "Tage"),
+            "fixed_price": ("pauschal", "pauschal"),
         },
     },
     "es": {


### PR DESCRIPTION
Two i18n fixes for German invoices:

1. VAT column header: 'MwSt.' -> 'USt.' (line-item column was inconsistent with footer which already uses 'USt.ID').

2. Add 'fixed_price' unit label ('pauschal') for lump-sum invoices; previously the English 'fixed price' was hardcoded.

Closes #336 and #337