### PR TITLE
fix(contacts): allow inline editing of client-contact roles

### DIFF
--- a/tuttle/app/contacts/intent.py
+++ b/tuttle/app/contacts/intent.py
@@ -72,6 +72,28 @@ class ContactsIntent(CrudIntent):
                 exception=e,
             )
 
+    def update_client_contact_role(
+        self, association_id: int, role: str | None
+    ) -> IntentResult:
+        """Update the role on a ClientContact association."""
+        try:
+            assoc = self.query_by_id(ClientContact, association_id)
+            if assoc is None:
+                return IntentResult(
+                    was_intent_successful=False,
+                    error_msg="Association not found.",
+                )
+            assoc.role = role
+            self.store(assoc)
+            return IntentResult(was_intent_successful=True, data=assoc)
+        except Exception as e:
+            return IntentResult(
+                was_intent_successful=False,
+                error_msg="Failed to update contact role.",
+                log_message=f"update_client_contact_role({association_id}): {e}",
+                exception=e,
+            )
+
     def _validated_save(self, contact: Contact) -> IntentResult:
         if not contact.first_name or not contact.last_name:
             return IntentResult(

--- a/ui/src/components/business/ClientsView.tsx
+++ b/ui/src/components/business/ClientsView.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import {
   Building2, Plus, Trash2, Save, X, Mail, MapPin, Users,
-  FileUp, Sparkles, Check, CheckCheck, Loader2, UserPlus, Tag,
+  FileUp, Sparkles, Check, CheckCheck, Loader2, UserPlus,
 } from "lucide-react";
 import { rpc } from "../../api/rpc";
 import { str, num, entity as subEntity, displayName, fullName } from "../../api/entity";
 import { Toolbar, ToolbarButtonPrimary, ToolbarButtonSecondary, ListDetailLayout, LIST_ROW_PADDING } from "../shared/ToolbarButtons";
+import { EditableClientContactRole } from "../shared/EditableClientContactRole";
 import type { Entity } from "../../api/types";
 
 type Mode = "view" | "edit" | "create" | "import";
@@ -361,11 +362,8 @@ function ClientDetail({ client, contacts, onEdit, onDelete, deleteError, onReloa
               <span className="text-tertiary"><Users size={14} /></span>
               <div className="flex-1 min-w-0">
                 <div className="text-sm font-medium truncate">{ctName}</div>
-                {role && (
-                  <div className="flex items-center gap-1 text-xs text-tertiary">
-                    <Tag size={10} /> {role}
-                  </div>
-                )}
+                <EditableClientContactRole associationId={a.id} role={role} onUpdated={loadAssocs}
+                  updateMethod="clients.update_client_contact_role" />
               </div>
               <button onClick={() => removeAssoc(a.id)}
                 className="opacity-0 group-hover:opacity-100 p-1 rounded text-secondary hover:text-red-400 transition-all"

--- a/ui/src/components/contacts/ContactsView.tsx
+++ b/ui/src/components/contacts/ContactsView.tsx
@@ -6,6 +6,7 @@ import {
 import { rpc } from "../../api/rpc";
 import { str, num, entity as subEntity, fullName, initials, displayName } from "../../api/entity";
 import { Toolbar, ToolbarButtonPrimary, ToolbarButtonSecondary, ListDetailLayout, LIST_ROW_PADDING } from "../shared/ToolbarButtons";
+import { EditableClientContactRole } from "../shared/EditableClientContactRole";
 import type { Entity } from "../../api/types";
 
 type Mode = "view" | "edit" | "create" | "import";
@@ -364,11 +365,8 @@ function ContactDetail({ contact, clients, onEdit, onDelete }: {
               <span className="text-tertiary"><Building2 size={14} /></span>
               <div className="flex-1 min-w-0">
                 <div className="text-sm font-medium truncate">{clientName || `Client #${num(a, "client_id")}`}</div>
-                {role && (
-                  <div className="flex items-center gap-1 text-xs text-tertiary">
-                    <Tag size={10} /> {role}
-                  </div>
-                )}
+                <EditableClientContactRole associationId={a.id} role={role} onUpdated={loadAssocs}
+                  updateMethod="contacts.update_client_contact_role" />
               </div>
               <button onClick={() => removeAssoc(a.id)}
                 className="opacity-0 group-hover:opacity-100 p-1 rounded text-secondary hover:text-red-400 transition-all"
@@ -550,11 +548,8 @@ function ContactForm({ contact, clients, onSave, onCancel }: {
                   <span className="text-tertiary"><Building2 size={14} /></span>
                   <div className="flex-1 min-w-0">
                     <div className="text-sm font-medium truncate">{clientName || `Client #${num(a, "client_id")}`}</div>
-                    {role && (
-                      <div className="flex items-center gap-1 text-xs text-tertiary">
-                        <Tag size={10} /> {role}
-                      </div>
-                    )}
+                    <EditableClientContactRole associationId={a.id} role={role} onUpdated={loadAssocs}
+                  updateMethod="contacts.update_client_contact_role" />
                   </div>
                   <button type="button" onClick={() => removeAssoc(a.id)}
                     className="opacity-0 group-hover:opacity-100 p-1 rounded text-secondary hover:text-red-400 transition-all"

--- a/ui/src/components/shared/EditableClientContactRole.tsx
+++ b/ui/src/components/shared/EditableClientContactRole.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import { Tag, Pencil } from "lucide-react";
+import { rpc } from "../../api/rpc";
+
+type UpdateRoleMethod =
+  | "contacts.update_client_contact_role"
+  | "clients.update_client_contact_role";
+
+export function EditableClientContactRole({ associationId, role, onUpdated, updateMethod }: {
+  associationId: number;
+  role: string;
+  onUpdated: () => void;
+  updateMethod: UpdateRoleMethod;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(role);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => { setValue(role); }, [role]);
+
+  async function save() {
+    const newRole = value.trim() || null;
+    const currentRole = role.trim() || null;
+    if (newRole === currentRole) {
+      setEditing(false);
+      return;
+    }
+    setSaving(true);
+    const res = await rpc(updateMethod, {
+      association_id: associationId,
+      role: newRole,
+    });
+    setSaving(false);
+    if (res.ok) {
+      setEditing(false);
+      await onUpdated();
+    }
+  }
+
+  function cancel() {
+    setValue(role);
+    setEditing(false);
+  }
+
+  if (editing) {
+    return (
+      <div className="flex items-center gap-2 mt-0.5">
+        <input type="text" value={value} autoFocus disabled={saving}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Escape") cancel(); }}
+          placeholder="Role (optional), e.g. project lead, accountant"
+          className="flex-1 min-w-0 px-2 py-1 rounded text-xs bg-bg-sidebar text-primary border border-accent outline-none transition-colors placeholder:text-muted disabled:opacity-50" />
+        <button type="button" onClick={cancel} disabled={saving}
+          className="px-2 py-1 rounded text-xs text-secondary hover:text-primary transition-colors disabled:opacity-50">
+          Cancel
+        </button>
+        <button type="button" onClick={save} disabled={saving}
+          className="px-2 py-1 rounded text-xs font-medium text-primary bg-accent/20 hover:bg-accent/30 border border-accent/30 transition-colors disabled:opacity-40">
+          {saving ? "Saving…" : "Save"}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button type="button" onClick={() => setEditing(true)}
+      className="flex items-center gap-1 text-xs text-tertiary hover:text-primary transition-colors group/role"
+      title="Edit role">
+      <Tag size={10} />
+      {role || <span className="italic text-muted">Add role…</span>}
+      <Pencil size={10} className="opacity-0 group-hover/role:opacity-100 transition-opacity" />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

- Expose `update_client_contact_role` on the contacts RPC namespace (it already existed on `ClientsIntent`)
- Add a shared `EditableClientContactRole` component with click-to-edit and explicit Save/Cancel buttons
- Wire role editing into both **Contacts** and **Clients** detail views so associations can be updated from either side

Fixes #338

## Test plan

- [x] `uv run pytest --tb=short -q` (309 passed)
- [x] Open a contact linked to a client → click role tag → edit → Save → role persists
- [x] Open a client with linked contacts → same flow from the Contacts section
- [ ] Verify Cancel discards unsaved edits
- [ ] Verify "Add role…" works when no role is set


Made with [Cursor](https://cursor.com)