### PR TITLE
fix(invoice): German VAT label and fixed-price unit localization

### DIFF
--- a/tuttle/invoicing.py
+++ b/tuttle/invoicing.py
@@ -71,7 +71,7 @@ def generate_fixed_price_invoice(
         vat_rate = vat_rate / Decimal("100")
     item = InvoiceItem(
         quantity=1,
-        unit="fixed price",
+        unit="fixed_price",
         unit_price=Decimal(str(contract.fixed_price)),
         VAT_rate=vat_rate,
         description=contract.title,

--- a/tuttle/rendering.py
+++ b/tuttle/rendering.py
@@ -50,6 +50,7 @@ INVOICE_LABELS = {
         "units": {
             "hour": ("hour", "hours"),
             "day": ("day", "days"),
+            "fixed_price": ("fixed price", "fixed price"),
         },
     },
     "de": {
@@ -63,7 +64,7 @@ INVOICE_LABELS = {
         "qty": "Menge",
         "unit": "Einheit",
         "unit_price": "Einzelpreis",
-        "vat": "MwSt.",
+        "vat": "USt.",
         "subtotal": "Zwischensumme",
         "total_due": "Gesamtbetrag",
         "payment": "Zahlung",
@@ -79,6 +80,7 @@ INVOICE_LABELS = {
         "units": {
             "hour": ("Stunde", "Stunden"),
             "day": ("Tag", "Tage"),
+            "fixed_price": ("pauschal", "pauschal"),
         },
     },
     "es": {
@@ -108,6 +110,7 @@ INVOICE_LABELS = {
         "units": {
             "hour": ("hora", "horas"),
             "day": ("día", "días"),
+            "fixed_price": ("precio fijo", "precio fijo"),
         },
     },
 }
@@ -195,7 +198,8 @@ def render_invoice(
         Unknown units pass through unchanged.
         """
         units = labels.get("units", {})
-        forms = units.get(raw_unit)
+        normalized = raw_unit.replace(" ", "_")
+        forms = units.get(normalized)
         if not forms:
             return raw_unit
         singular, plural = forms


### PR DESCRIPTION
## Summary

- Fix German VAT column header: "MwSt." → "USt." (aligns with footer which uses "USt.ID")
- Add localized `fixed_price` unit label for lump-sum invoices (de: "pauschal", es: "precio fijo")
- Normalize unit key in `generate_fixed_price_invoice` to `"fixed_price"` (snake_case, consistent with `"hour"`/`"day"`)
- Add backward-compat normalization in `unit_label` filter (space → underscore) for existing stored invoices

Closes #336, closes #337

Supersedes #342 (addresses the key-mismatch issue flagged in review).

## Test plan

- [x] All 313 existing tests pass
- [ ] Generate a fixed-price invoice in German → verify "pauschal" appears in unit column
- [ ] Generate a time-based invoice in German → verify "USt." in VAT column header

Made with [Cursor](https://cursor.com)