### PR TITLE
fix(core): bundle every RPC domain into frozen build + regression coverage

### DIFF
--- a/.github/workflows/pack-electron.yml
+++ b/.github/workflows/pack-electron.yml
@@ -35,7 +35,7 @@ jobs:
       if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install -y rpm
 
-    # Python sidecar
+    # Python core
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -44,8 +44,12 @@ jobs:
       run: uv python install 3.13
     - name: Install Python dependencies
       run: uv sync --all-groups
-    - name: Build Python sidecar (PyInstaller)
+    - name: Build Python core (PyInstaller)
       run: uv run pyinstaller --clean --noconfirm tuttle-rpc.spec
+    # Verify the frozen binary actually bundles every RPC domain before the
+    # expensive Electron packaging step (fail-fast on packaging regressions).
+    - name: Smoke-test core (every domain bundled)
+      run: uv run python scripts/smoke_core.py
 
     # Electron app
     - name: Set up Node.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ local development.
 
 ## Running the App
 
-Start the Electron app in development mode. The Python RPC sidecar is
+Start the Electron app in development mode. The Python RPC core is
 spawned automatically:
 
 ```shell
@@ -175,7 +175,7 @@ launch. Use `just reset-dev` to wipe the dev data directory.
 just build
 ```
 
-This builds the Python sidecar with PyInstaller and packages the Electron
+This builds the Python core with PyInstaller and packages the Electron
 app with electron-builder.
 
 # Pull Request Guidelines

--- a/justfile
+++ b/justfile
@@ -22,9 +22,13 @@ dev:
 
 # ── Build ───────────────────────────────────────────────────────────────────
 
-# Build the Python RPC sidecar with PyInstaller
-build-sidecar:
+# Build the Python RPC core with PyInstaller
+build-core:
     {{python}} -m PyInstaller --clean --noconfirm {{repo}}/tuttle-rpc.spec
+
+# Smoke-test the frozen core: verify every RPC domain is bundled
+smoke-core:
+    {{python}} {{repo}}/scripts/smoke_core.py
 
 # Build the Electron renderer (Vite + TypeScript)
 build-renderer:
@@ -34,15 +38,15 @@ build-renderer:
 clean-app:
     rm -rf "{{electron}}/release"
 
-# Package the Electron .app (requires build-sidecar + build-renderer first)
+# Package the Electron .app (requires build-core + build-renderer first)
 pack target="dir":
     cd {{electron}} && CSC_IDENTITY_AUTO_DISCOVERY=false npx electron-builder --mac {{target}}
     @echo "Ad-hoc signing all binaries…"
     find "{{app}}" -type f \( -name '*.dylib' -o -name '*.so' -o -perm +111 \) -exec codesign --force --sign - {} \; 2>/dev/null || true
     codesign --force --deep --sign - "{{app}}"
 
-# Full build: sidecar → renderer → package (pass "dmg" for .dmg)
-build target="dir": clean-app build-sidecar build-renderer (pack target)
+# Full build: core → renderer → package (pass "dmg" for .dmg)
+build target="dir": clean-app build-core smoke-core build-renderer (pack target)
     @echo "✓ {{electron}}/release/"
 
 # Create a beta .zip with an install script that strips quarantine

--- a/scripts/pack_electron.py
+++ b/scripts/pack_electron.py
@@ -35,9 +35,9 @@ def _run(cmd: list[str], cwd: Path | None = None, check: bool = True):
     return result
 
 
-def build_python_sidecar():
+def build_python_core():
     """Run PyInstaller to produce dist/tuttle-rpc/."""
-    logger.info("Phase 1: Building Python sidecar with PyInstaller")
+    logger.info("Phase 1: Building Python core with PyInstaller")
 
     if not SPEC_FILE.exists():
         logger.error(f"PyInstaller spec not found: {SPEC_FILE}")
@@ -65,7 +65,11 @@ def build_python_sidecar():
         logger.error(f"Executable not found: {exe}")
         raise typer.Exit(code=1)
 
-    logger.info(f"Python sidecar ready at {dist}")
+    logger.info(f"Python core ready at {dist}")
+
+    # Fail fast if the frozen binary is missing any RPC domain.
+    logger.info("Smoke-testing core: verifying every RPC domain is bundled")
+    _run([sys.executable, str(REPO_ROOT / "scripts" / "smoke_core.py")])
 
 
 def build_electron():
@@ -101,13 +105,13 @@ def main(
     ),
 ):
     if not skip_python:
-        build_python_sidecar()
+        build_python_core()
     else:
-        logger.info("Skipping Python sidecar build (--skip-python)")
+        logger.info("Skipping Python core build (--skip-python)")
         dist = REPO_ROOT / "dist" / "tuttle-rpc"
         if not dist.exists():
             logger.warning(
-                f"No existing sidecar at {dist} -- electron-builder will fail"
+                f"No existing core build at {dist} -- electron-builder will fail"
             )
 
     build_electron()

--- a/scripts/smoke_core.py
+++ b/scripts/smoke_core.py
@@ -1,0 +1,120 @@
+"""Smoke-test the frozen PyInstaller core binary.
+
+Spawns the actual ``dist/tuttle-rpc`` binary and verifies that every RPC
+domain (a ``tuttle/app/<domain>/intent.py`` on disk) is bundled and importable
+in the frozen build. This catches the class of release regression where a
+dynamically-imported intent module is silently dropped from the binary,
+producing ``No module named 'tuttle.app.<domain>'`` only in the distributed app.
+
+How it works: the dispatcher imports ``tuttle.app.<domain>.intent`` on the first
+call to any method of that domain. We send each domain a sentinel method name:
+
+    - missing from bundle  -> error contains "No module named 'tuttle.app.<domain>'"  (FAIL)
+    - bundled & importable -> error contains "No handler for ..."                       (PASS)
+
+No database or valid parameters are required.
+
+Usage:
+    uv run python scripts/smoke_core.py
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+APP_DIR = REPO_ROOT / "tuttle" / "app"
+PROBE_METHOD = "__smoke_probe__"
+
+
+def discover_domains() -> list[str]:
+    """Names of every directory under tuttle/app that has intent.py (except core)."""
+    return sorted(
+        p.parent.name for p in APP_DIR.glob("*/intent.py") if p.parent.name != "core"
+    )
+
+
+def core_binary() -> Path:
+    exe = "tuttle-rpc.exe" if sys.platform.startswith("win") else "tuttle-rpc"
+    return REPO_ROOT / "dist" / "tuttle-rpc" / exe
+
+
+def main() -> int:
+    binary = core_binary()
+    if not binary.exists():
+        print(f"ERROR: core binary not found at {binary}", file=sys.stderr)
+        print(
+            "Build it first: uv run pyinstaller --clean --noconfirm tuttle-rpc.spec",
+            file=sys.stderr,
+        )
+        return 1
+
+    domains = discover_domains()
+    if not domains:
+        print("ERROR: no domains discovered under tuttle/app/", file=sys.stderr)
+        return 1
+
+    print(f"Probing {len(domains)} domains against {binary.name}: {domains}")
+
+    proc = subprocess.Popen(
+        [str(binary)],
+        cwd=str(binary.parent),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+
+    failures: list[str] = []
+    try:
+        for i, domain in enumerate(domains, start=1):
+            request = {
+                "jsonrpc": "2.0",
+                "id": i,
+                "method": f"{domain}.{PROBE_METHOD}",
+                "params": {},
+            }
+            proc.stdin.write(json.dumps(request) + "\n")
+            proc.stdin.flush()
+
+            line = proc.stdout.readline()
+            if not line:
+                failures.append(f"{domain}: no response (core died?)")
+                break
+
+            response = json.loads(line)
+            blob = json.dumps(response)
+
+            if f"No module named 'tuttle.app.{domain}'" in blob or (
+                "No module named" in blob and f"tuttle.app.{domain}" in blob
+            ):
+                failures.append(f"{domain}: NOT bundled in frozen binary -> {blob}")
+            else:
+                print(f"  ok   {domain}")
+    finally:
+        proc.stdin.close()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    if failures:
+        print("\nSMOKE TEST FAILED:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        print(
+            "\nA domain reachable via the dispatcher is missing from the frozen "
+            "build. Check tuttle-rpc.spec (collect_submodules) and that the "
+            "domain directory has an __init__.py.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\nSMOKE TEST PASSED: all {len(domains)} domains bundled & importable.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tuttle-rpc.spec
+++ b/tuttle-rpc.spec
@@ -1,5 +1,5 @@
 # -*- mode: python ; coding: utf-8 -*-
-"""PyInstaller spec for the tuttle RPC sidecar.
+"""PyInstaller spec for the tuttle RPC core.
 
 Bundles tuttle/rpc_server.py as the entry point, pulling in the full
 CPython interpreter, the entire tuttle package, all Python dependencies,
@@ -13,6 +13,8 @@ Usage:
 import sys
 from importlib.util import find_spec
 from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_submodules
 
 block_cipher = None
 
@@ -50,26 +52,12 @@ if _drafthorse_spec and _drafthorse_spec.submodule_search_locations:
 # Hidden imports -- lazily imported modules PyInstaller can't trace
 # ---------------------------------------------------------------------------
 
-hiddenimports = [
-    # Intent classes (loaded dynamically by the dispatcher on first RPC call)
-    "tuttle.app.auth.intent",
-    "tuttle.app.clients.intent",
-    "tuttle.app.contacts.intent",
-    "tuttle.app.contracts.intent",
-    "tuttle.app.dashboard.intent",
-    "tuttle.app.db.intent",
-    "tuttle.app.demo.intent",
-    "tuttle.app.invoicing.intent",
-    "tuttle.app.invoicing.data_source",
-    "tuttle.app.llm.intent",
-    "tuttle.app.preferences.intent",
-    "tuttle.app.projects.intent",
-    "tuttle.app.salary.intent",
-    "tuttle.app.settings.intent",
-    "tuttle.app.tax.intent",
-    "tuttle.app.timetracking.intent",
-    "tuttle.app.timeline.intent",
-    "tuttle.app.users.intent",
+# Intent classes are loaded dynamically by the dispatcher (importlib) on the
+# first RPC call, so PyInstaller's static analyzer can't trace them. Auto-collect
+# every submodule of tuttle.app instead of hand-listing them — a hand-maintained
+# list silently drops any newly added domain from the frozen build (e.g. the
+# 'imports' domain regression).
+hiddenimports = collect_submodules("tuttle.app") + [
     # Supporting modules
     "tuttle.app.core.database_storage_impl",
     "tuttle.app.core.formatting",

--- a/tuttle_tests/test_rpc_dispatch.py
+++ b/tuttle_tests/test_rpc_dispatch.py
@@ -8,15 +8,34 @@ Catches detached-instance errors, missing modules, serialisation bugs, and
 data-shape mismatches between the Python core and the frontend.
 """
 
+import importlib
 import json
 from pathlib import Path
 
 import pytest
 
+import tuttle.app
 import tuttle.app.core.abstractions as abstractions
 import tuttle.app_db as app_db_mod
 from tuttle.app.core.dispatch import dispatch, _intents
 from tuttle.app.core.rpc_utils import reset_all
+
+
+# ---------------------------------------------------------------------------
+# Discover every RPC domain on disk: a subpackage of tuttle.app with intent.py
+# ---------------------------------------------------------------------------
+
+_APP_DIR = Path(tuttle.app.__file__).parent
+
+
+def _discover_domains() -> list[str]:
+    """Return the names of every directory under tuttle/app that has intent.py."""
+    return sorted(
+        p.parent.name for p in _APP_DIR.glob("*/intent.py") if p.parent.name != "core"
+    )
+
+
+DOMAINS = _discover_domains()
 
 
 # ---------------------------------------------------------------------------
@@ -232,3 +251,75 @@ class TestSerialization:
                 json.dumps(result)
             except (TypeError, ValueError) as exc:
                 pytest.fail(f"{method} response not JSON-serializable: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# 4. Domain packaging integrity
+#
+# The dispatcher resolves "domain.method" by importing tuttle.app.{domain}.intent
+# at runtime (importlib). Two failure modes are invisible to the route tests
+# above because those run against the source tree with a hand-picked route list:
+#
+#   1. A domain directory without __init__.py is not a Python package, so both
+#      importlib AND PyInstaller's collect_submodules silently skip it.
+#   2. The frozen build (tuttle-rpc.spec) may not bundle a dynamically-imported
+#      domain, producing "No module named 'tuttle.app.{domain}'" only in the
+#      distributed .app — never in dev.
+#
+# These tests guard both for EVERY domain on disk, so a newly added domain can
+# never be silently dropped from dev or the release bundle.
+# ---------------------------------------------------------------------------
+
+
+class TestDomainPackaging:
+    def test_domains_discovered(self):
+        """Sanity: discovery finds the known domains (and any new ones)."""
+        assert "imports" in DOMAINS
+        assert "invoicing" in DOMAINS
+        assert len(DOMAINS) >= 10
+
+    @pytest.mark.parametrize("domain", DOMAINS)
+    def test_domain_is_importable_package(self, domain):
+        """Each domain must be a real package with an importable intent module.
+
+        Catches the missing-__init__.py class of bug for ALL domains, mirroring
+        exactly what the dispatcher does at runtime.
+        """
+        pkg_init = _APP_DIR / domain / "__init__.py"
+        assert pkg_init.exists(), (
+            f"tuttle/app/{domain}/ has intent.py but no __init__.py — it is not "
+            f"a package, so the dispatcher and the frozen build will skip it."
+        )
+        mod = importlib.import_module(f"tuttle.app.{domain}.intent")
+        candidates = [
+            name
+            for name in dir(mod)
+            if name.endswith("Intent")
+            and getattr(getattr(mod, name), "__module__", None) == mod.__name__
+        ]
+        assert len(candidates) == 1, (
+            f"tuttle.app.{domain}.intent must define exactly one *Intent class, "
+            f"found {candidates}"
+        )
+
+    def test_frozen_build_bundles_every_domain(self):
+        """The PyInstaller spec must bundle every dynamically-imported domain.
+
+        Uses the same collect_submodules() the spec relies on. Skips when
+        PyInstaller isn't installed (it lives in the 'build' dependency group).
+        This is the guard that the original release regression lacked.
+        """
+        pytest.importorskip("PyInstaller")
+        from PyInstaller.utils.hooks import collect_submodules
+
+        bundled = set(collect_submodules("tuttle.app"))
+        missing = [
+            f"tuttle.app.{d}.intent"
+            for d in DOMAINS
+            if f"tuttle.app.{d}.intent" not in bundled
+        ]
+        assert not missing, (
+            f"These domains are reachable via the dispatcher but would NOT be "
+            f"bundled into the frozen tuttle-rpc binary: {missing}. "
+            f"Check tuttle-rpc.spec and the domain's __init__.py."
+        )

--- a/ui/electron/python-bridge.ts
+++ b/ui/electron/python-bridge.ts
@@ -8,7 +8,7 @@ type PendingRequest = {
 };
 
 /**
- * Manages the Python RPC sidecar process.
+ * Manages the Python RPC core process.
  * Communicates via newline-delimited JSON-RPC 2.0 over stdio.
  *
  * In dev mode, spawns .venv/bin/python -m tuttle.rpc_server.

--- a/uv.lock
+++ b/uv.lock
@@ -3524,7 +3524,7 @@ wheels = [
 
 [[package]]
 name = "tuttle"
-version = "3.11.0"
+version = "3.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

The distributed macOS app failed when committing from **AI Document Import** with:

> Error invoking remote method 'rpc': Error: No module named 'tuttle.app.imports'

**Root cause:** the frozen PyInstaller core resolves intent modules dynamically via `importlib` (`tuttle.app.{domain}.intent`), so PyInstaller's static analyzer can't trace them. Each domain therefore had to be hand-listed in `tuttle-rpc.spec`'s `hiddenimports`. The `imports` domain (and, latently, `invoice_notes`) was never added, so it was silently dropped from the release binary — even though it worked fine in dev. A missing `__init__.py` (fixed in #351) was necessary but not sufficient.

## Changes

- **Real fix:** replace the fragile hand-maintained `hiddenimports` list with `collect_submodules("tuttle.app")`, so every present and future domain is always bundled. Verified it discovers all 19 intent modules, including `imports` and `invoice_notes`.
- **Unit guards** (`tuttle_tests/test_rpc_dispatch.py`):
  - every `tuttle/app/<domain>` is a real importable package with exactly one `*Intent` class (catches missing `__init__.py`)
  - `collect_submodules` covers every on-disk domain (catches spec drift); skips if PyInstaller absent
- **End-to-end smoke test** (`scripts/smoke_core.py`): spawns the *actual frozen binary* and probes every domain, asserting none returns "No module named". Wired into CI before the expensive packaging step (fail-fast), into `pack_electron.py`, and as a `just smoke-core` recipe.
- **Terminology:** renamed the Python core from "sidecar" to "core" across build scripts, spec, workflow, bridge, and docs.

## Why the previous coverage missed this

The existing `test_rpc_dispatch.py` runs against the source tree, so it structurally cannot catch a packaging regression in the frozen binary. The new guards target the exact mechanism the release build depends on.

## Test plan

- [x] `uv run pytest -q` — 336 passed
- [x] Negative check: removing `tuttle/app/imports/__init__.py` makes both unit guards fail with a precise diagnostic
- [x] Built the frozen binary and ran `scripts/smoke_core.py` — all 19 domains bundled & importable
- [ ] CI green on the new "Smoke-test core" step across all platforms

Made with [Cursor](https://cursor.com)