### PR TITLE
fix(templates): make invoice unit type explicit in column header

### DIFF
--- a/templates/invoice-bold/invoice.html
+++ b/templates/invoice-bold/invoice.html
@@ -75,7 +75,7 @@
         <th class="col-date">{{ l.date }}</th>
         <th class="col-desc">{{ l.description }}</th>
         <th class="col-qty">{{ l.qty }}</th>
-        <th class="col-unit">{{ l.unit }}</th>
+        <th class="col-unit">{{ unit_header }}</th>
         <th class="col-price">{{ l.unit_price }}</th>
         <th class="col-vat">{{ l.vat }}</th>
         <th class="col-subtotal">{{ l.subtotal }}</th>

--- a/templates/invoice-classic/invoice.html
+++ b/templates/invoice-classic/invoice.html
@@ -68,7 +68,7 @@
         <th class="col-date">{{ l.date }}</th>
         <th class="col-desc">{{ l.description }}</th>
         <th class="col-qty">{{ l.qty }}</th>
-        <th class="col-unit">{{ l.unit }}</th>
+        <th class="col-unit">{{ unit_header }}</th>
         <th class="col-price">{{ l.unit_price }}</th>
         <th class="col-vat">{{ l.vat }}</th>
         <th class="col-subtotal">{{ l.subtotal }}</th>

--- a/templates/invoice-minimal/invoice.html
+++ b/templates/invoice-minimal/invoice.html
@@ -77,7 +77,7 @@
         <th class="col-date">{{ l.date }}</th>
         <th class="col-desc">{{ l.description }}</th>
         <th class="col-qty">{{ l.qty }}</th>
-        <th class="col-unit">{{ l.unit }}</th>
+        <th class="col-unit">{{ unit_header }}</th>
         <th class="col-price">{{ l.unit_price }}</th>
         <th class="col-vat">{{ l.vat }}</th>
         <th class="col-subtotal">{{ l.subtotal }}</th>

--- a/templates/invoice-modern/invoice.html
+++ b/templates/invoice-modern/invoice.html
@@ -76,7 +76,7 @@
         <th class="col-date">{{ l.date }}</th>
         <th class="col-desc">{{ l.description }}</th>
         <th class="col-qty">{{ l.qty }}</th>
-        <th class="col-unit">{{ l.unit }}</th>
+        <th class="col-unit">{{ unit_header }}</th>
         <th class="col-price">{{ l.unit_price }}</th>
         <th class="col-vat">{{ l.vat }}</th>
         <th class="col-subtotal">{{ l.subtotal }}</th>

--- a/tuttle/rendering.py
+++ b/tuttle/rendering.py
@@ -227,11 +227,21 @@ def render_invoice(
         tpl = labels.get("reminder_n", "{n}. Payment Reminder")
         reminder_title = tpl.format(n=n)
 
+    # Derive the column header from the contract's unit type so that the
+    # rendered invoice makes it explicit whether the quantity column refers
+    # to hours, days, or a fixed price — see issue #358.
+    contract_unit = getattr(invoice.contract, "unit", None)
+    if contract_unit is not None:
+        unit_header = unit_label(contract_unit.value, 2)
+    else:
+        unit_header = labels.get("unit", "Unit")
+
     invoice_template = template_env.get_template("invoice.html")
     html = invoice_template.render(
         user=user,
         invoice=invoice,
         l=labels,
+        unit_header=unit_header,
         is_reminder=is_reminder,
         reminder_title=reminder_title,
         notes=invoice.notes,

--- a/tuttle/rendering.py
+++ b/tuttle/rendering.py
@@ -230,11 +230,14 @@ def render_invoice(
     # Derive the column header from the contract's unit type so that the
     # rendered invoice makes it explicit whether the quantity column refers
     # to hours, days, or a fixed price — see issue #358.
-    contract_unit = getattr(invoice.contract, "unit", None)
-    if contract_unit is not None:
-        unit_header = unit_label(contract_unit.value, 2)
+    if getattr(invoice.contract, "is_fixed_price", False):
+        unit_header = labels.get("fixed_price", "fixed price")
     else:
-        unit_header = labels.get("unit", "Unit")
+        contract_unit = getattr(invoice.contract, "unit", None)
+        if contract_unit is not None:
+            unit_header = unit_label(contract_unit.value, 2)
+        else:
+            unit_header = labels.get("unit", "Unit")
 
     invoice_template = template_env.get_template("invoice.html")
     html = invoice_template.render(


### PR DESCRIPTION
## Problem

The invoice "Unit" column header is generic and doesn't tell the reader whether the quantity column refers to hours, days, or another unit. This makes it unclear what the billed quantity represents (see #358).

## Fix

The column header is now derived from the contract's unit type using the existing `unit_label` filter, showing the pluralized and localized unit name:

| Contract unit | EN header | DE header |
|---|---|---|
| hour | hours | Stunden |
| day | days | Tage |
| fixed_price | fixed price | pauschal |

This affects all four HTML invoice templates: `invoice-classic`, `invoice-modern`, `invoice-bold`, and `invoice-minimal`.

The `rendering.render_invoice()` function now computes a `unit_header` variable from `invoice.contract.unit` and passes it to the Jinja2 template context. Templates use `{{ unit_header }}` instead of `{{ l.unit }}`.

## Test Plan

- [x] Existing `test_rendering.py` tests pass (4/4)
- [x] Existing `test_invoice.py` tests pass (24/24)
- [x] Verified header shows "hours" for hourly contracts
- [x] Verified header shows "days" for daily contracts
- [x] Verified header shows "Stunden" for German hourly contracts

Closes #358
