### PR TITLE
fix(templates): make billing unit explicit in grayshades invoice

### DIFF
--- a/templates/invoice-grayshades/invoice.css
+++ b/templates/invoice-grayshades/invoice.css
@@ -166,11 +166,12 @@ body {
 }
 
 /* Column widths */
-.col-date { width: 19%; }
-.col-qty { width: 8%; text-align: center; }
-.col-desc { width: 33%; }
-.col-price { width: 19%; text-align: right; }
-.col-subtotal { width: 21%; text-align: right; }
+.col-date { width: 18%; }
+.col-qty { width: 7%; text-align: center; }
+.col-unit { width: 10%; }
+.col-desc { width: 27%; }
+.col-price { width: 18%; text-align: right; }
+.col-subtotal { width: 20%; text-align: right; }
 
 .items-table thead th.col-qty { text-align: center; }
 .items-table thead th.col-price { text-align: right; }

--- a/templates/invoice-grayshades/invoice.html
+++ b/templates/invoice-grayshades/invoice.html
@@ -54,6 +54,7 @@
       <tr>
         <th class="col-date">{{ l.date }}</th>
         <th class="col-qty">{{ l.qty }}</th>
+        <th class="col-unit">{{ l.unit }}</th>
         <th class="col-desc">{{ l.description }}</th>
         <th class="col-price">{{ l.unit_price }} (€)</th>
         <th class="col-subtotal">{{ l.subtotal }} (€)</th>
@@ -64,6 +65,7 @@
       <tr>
         <td class="col-date">{{ item.start_date | as_date_short }}&ndash;{{ item.end_date | as_date_short }}</td>
         <td class="col-qty">{{ item.quantity }}</td>
+        <td class="col-unit">{{ item.unit | unit_label(item.quantity) }}</td>
         <td class="col-desc">{{ item.description }}</td>
         <td class="col-price num">{{ item.unit_price | as_currency }}</td>
         <td class="col-subtotal num">{{ item.subtotal | as_currency }}</td>


### PR DESCRIPTION
## Problem

Issue #358: on the invoice the billed quantity (e.g. `6`) gave no indication of the unit, so a reader could not tell whether it meant 6 *hours* or 6 *days*.

The screenshot in #358 is the **`invoice-grayshades`** template, whose item table was `Date | Qty | Description | Unit Price (€) | Subtotal (€)` — with **no unit column at all**.

## Root cause

I audited every invoice template by rendering each one. Six of the seven templates (`invoice`, `invoice-anvil`, `invoice-bold`, `invoice-classic`, `invoice-minimal`, `invoice-modern`) already had a localized `Unit` column (added in `30169b7`). **`invoice-grayshades` was the only template missing it** — and it is exactly the one shown in the issue.

(For reference: the earlier PR #360 changed the *header* of the four templates that already showed the unit per row — producing a redundant "Hours" header above cells that already read "hours" — and never touched `grayshades`, so it did not fix the template in the issue.)

## Fix

Add a localized `Unit` column to `invoice-grayshades`, between `Qty` and `Description`, reusing the existing `unit_label` filter used by all other templates, and rebalance the column widths.

After the change the column header and cells localize and pluralize correctly:

| Contract unit | EN | DE |
| --- | --- | --- |
| hour (qty 6 / 1) | hours / hour | Stunden / Stunde |
| day (qty 3 / 1) | days / day | Tage / Tag |
| fixed price | fixed price | pauschal |

## Test plan

- [x] Rendered all 7 invoice templates to PDF via the real `rendering.render_invoice` code path and visually confirmed every template now shows the unit.
- [x] Verified `grayshades` localization/pluralization for en (`hours`/`hour`), de (`Tage`/`Stunde`), and fixed-price (`fixed price`).
- [x] Full test suite passes (`uv run pytest -q` → 340 passed).

Closes #358

Made with [Cursor](https://cursor.com)