### PR TITLE
feat(client): enhance client extraction with VAT and address support

### DIFF
--- a/tuttle/app/imports/intent.py
+++ b/tuttle/app/imports/intent.py
@@ -124,6 +124,7 @@ class ImportsIntent(SQLModelDataSourceMixin):
                         ref_to_id,
                         summary,
                         ref_fks={"contact_ref": "invoicing_contact_id"},
+                        nested={"address": Address},
                     )
 
                 for item in data.get("contracts", []):

--- a/tuttle/llm.py
+++ b/tuttle/llm.py
@@ -192,7 +192,13 @@ class _ContactExtract(_ContactScalarExtract):  # type: ignore[valid-type]
     address: Optional[_AddressExtract] = None  # type: ignore[valid-type]
 
 
-_ClientExtract = _flat_schema(Client, include=["name"])
+_ClientScalarExtract = _flat_schema(Client, include=["name", "vat_number"])
+
+
+class _ClientExtract(_ClientScalarExtract):  # type: ignore[valid-type]
+    address: Optional[_AddressExtract] = None  # type: ignore[valid-type]
+
+
 _ContractExtract = _flat_schema(
     Contract,
     include=[
@@ -439,6 +445,17 @@ def _map_clients(result: ClientExtractionResult) -> List[Dict[str, Any]]:
     results = []
     for item in result.items:
         d = {"name": getattr(item.client, "name", "") or ""}
+        d["vat_number"] = getattr(item.client, "vat_number", "") or ""
+        addr = {}
+        if item.client.address:
+            addr = {
+                "street": getattr(item.client.address, "street", "") or "",
+                "number": getattr(item.client.address, "number", "") or "",
+                "city": getattr(item.client.address, "city", "") or "",
+                "postal_code": getattr(item.client.address, "postal_code", "") or "",
+                "country": getattr(item.client.address, "country", "") or "",
+            }
+        d["address"] = addr
         d["contact_name_hint"] = item.contact_name_hint or ""
         results.append(d)
     return results

--- a/tuttle_tests/test_document_import.py
+++ b/tuttle_tests/test_document_import.py
@@ -7,6 +7,7 @@ import pytest
 from sqlmodel import Session, SQLModel, create_engine, select
 
 from tuttle.model import (
+    Address,
     Client,
     Contract,
     Invoice,
@@ -296,6 +297,72 @@ class TestInvoiceImport:
 
         result = intent.commit_import(data)
         assert result.was_intent_successful
+
+
+class TestClientAddressImport:
+    """Regression guard: client address extraction must persist an Address row."""
+
+    def test_commit_client_with_address(self, in_memory_db):
+        """Import a client with a nested address dict creates Address + Client."""
+        intent = ImportsIntent()
+
+        data = {
+            "contacts": [],
+            "clients": [
+                {
+                    "ref": "client_1",
+                    "name": "Acme Corp",
+                    "vat_number": "DE123456789",
+                    "address": {
+                        "street": "Hauptstraße",
+                        "number": "42",
+                        "city": "Berlin",
+                        "postal_code": "10115",
+                        "country": "Germany",
+                    },
+                }
+            ],
+            "contracts": [],
+            "projects": [],
+            "invoices": [],
+        }
+
+        result = intent.commit_import(data)
+        assert result.was_intent_successful
+
+        with Session(in_memory_db) as session:
+            client = session.exec(select(Client)).one()
+            assert client.name == "Acme Corp"
+            assert client.vat_number == "DE123456789"
+            assert client.address_id is not None
+
+            addr = session.get(Address, client.address_id)
+            assert addr is not None
+            assert addr.street == "Hauptstraße"
+            assert addr.number == "42"
+            assert addr.city == "Berlin"
+            assert addr.postal_code == "10115"
+            assert addr.country == "Germany"
+
+    def test_commit_client_without_address(self, in_memory_db):
+        """A client with no address dict still imports fine."""
+        intent = ImportsIntent()
+
+        data = {
+            "contacts": [],
+            "clients": [{"ref": "client_1", "name": "No Address Inc"}],
+            "contracts": [],
+            "projects": [],
+            "invoices": [],
+        }
+
+        result = intent.commit_import(data)
+        assert result.was_intent_successful
+
+        with Session(in_memory_db) as session:
+            client = session.exec(select(Client)).one()
+            assert client.name == "No Address Inc"
+            assert client.address_id is None
 
 
 class TestContractPricingInvariant:


### PR DESCRIPTION
- + Add vat_number to _ClientScalarExtract schema
- + Implement _ClientExtract class for address handling
- + Update _map_clients to include vat_number and address extraction
- + Add regression tests for client import with and without address

Closes #359




