### PR TITLE
fix(timetracking): show source chooser when calendar data is absent

### DIFF
--- a/tuttle/app/timetracking/intent.py
+++ b/tuttle/app/timetracking/intent.py
@@ -192,6 +192,8 @@ class TimeTrackingIntent(Intent):
 
     def get_source_config(self) -> IntentResult:
         config = self._timetracking_data_frame_source.get_source_config()
+        df = self._timetracking_data_frame_source.get_data_frame()
+        config["has_data"] = df is not None and not df.empty
         return IntentResult(was_intent_successful=True, data=config)
 
     def restore(self) -> IntentResult:
@@ -200,14 +202,14 @@ class TimeTrackingIntent(Intent):
         if ds.get_data_frame() is not None:
             return IntentResult(
                 was_intent_successful=True,
-                data={"restored": False, "reason": "already_loaded"},
+                data={"restored": False, "reason": "already_loaded", "has_data": True},
             )
         config = ds.get_source_config()
         source_type = config.get("source_type", "")
         if not source_type:
             return IntentResult(
                 was_intent_successful=True,
-                data={"restored": False, "reason": "no_config"},
+                data={"restored": False, "reason": "no_config", "has_data": False},
             )
         if source_type == "system" and is_available():
             calendar_id = config.get("calendar_id", "")
@@ -228,14 +230,20 @@ class TimeTrackingIntent(Intent):
                                 "restored": True,
                                 "source": "system",
                                 "count": len(new_df),
+                                "has_data": True,
                             },
                         )
                 except Exception as ex:
                     logger.warning(f"Failed to restore from system calendar: {ex}")
         restored = ds.load_from_cache()
+        has_data = ds.get_data_frame() is not None and not ds.get_data_frame().empty
         return IntentResult(
             was_intent_successful=True,
-            data={"restored": restored, "source": source_type if restored else "cache"},
+            data={
+                "restored": restored,
+                "source": source_type if restored else "cache",
+                "has_data": has_data,
+            },
         )
 
     def sync(self) -> IntentResult:

--- a/ui/src/components/timetracking/TimeTrackingView.tsx
+++ b/ui/src/components/timetracking/TimeTrackingView.tsx
@@ -84,6 +84,7 @@ export function TimeTrackingView() {
   const [sysCalLoading, setSysCalLoading] = useState(false);
   const [restoringSource, setRestoringSource] = useState(true);
   const [syncing, setSyncing] = useState(false);
+  const [connectionLost, setConnectionLost] = useState(false);
 
   const isMac = typeof window !== "undefined" && window.tuttle?.platform === "darwin";
 
@@ -97,9 +98,13 @@ export function TimeTrackingView() {
   useEffect(() => {
     (async () => {
       await rpc("timetracking.restore");
-      const cfgRes = await rpc<{ source_type: string }>("timetracking.get_source_config");
-      if (cfgRes.ok && cfgRes.data?.source_type) {
+      const cfgRes = await rpc<{ source_type: string; has_data: boolean }>("timetracking.get_source_config");
+      if (cfgRes.ok && cfgRes.data?.source_type && cfgRes.data.has_data) {
         setCalendarSource(cfgRes.data.source_type as CalendarSource);
+        setConnectionLost(false);
+      } else if (cfgRes.ok && cfgRes.data?.source_type && !cfgRes.data.has_data) {
+        setCalendarSource(null);
+        setConnectionLost(true);
       }
       setRestoringSource(false);
       loadData();
@@ -136,6 +141,7 @@ export function TimeTrackingView() {
     if (!files.length) return;
     setImporting(true);
     setCalendarSource("ics");
+    setConnectionLost(false);
     for (const file of Array.from(files)) {
       if (!file.name.endsWith(".ics")) continue;
       const buffer = await file.arrayBuffer();
@@ -173,6 +179,7 @@ export function TimeTrackingView() {
     setImporting(true);
     setSystemCals(null);
     setCalendarSource("system");
+    setConnectionLost(false);
     await rpc("timetracking.import_system_calendar", { calendar_id: calId });
     setImporting(false);
     loadData();
@@ -242,6 +249,7 @@ export function TimeTrackingView() {
               systemCals={systemCals}
               sysCalAuthStatus={sysCalAuthStatus}
               sysCalLoading={sysCalLoading}
+              connectionLost={connectionLost}
               onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
               onDragLeave={() => setDragOver(false)}
               onDrop={handleDrop}
@@ -364,11 +372,13 @@ export function TimeTrackingView() {
 
 function SourceChooser({
   dragOver, importing, isMac, systemCals, sysCalAuthStatus, sysCalLoading,
+  connectionLost,
   onDragOver, onDragLeave, onDrop, onLoadSystemCals, onImportSystemCal, onOpenSettings,
 }: {
   dragOver: boolean; importing: boolean; isMac: boolean;
   systemCals: SystemCalendar[] | null; sysCalAuthStatus: string | null;
   sysCalLoading: boolean;
+  connectionLost: boolean;
   onDragOver: (e: React.DragEvent) => void;
   onDragLeave: () => void;
   onDrop: (e: React.DragEvent) => void;
@@ -382,6 +392,11 @@ function SourceChooser({
 
   return (
     <div className="flex flex-col items-center justify-center h-full gap-5 px-6">
+      {connectionLost && (
+        <div className="px-4 py-2.5 rounded-lg bg-warning/10 border border-warning/30 text-xs text-warning max-w-sm text-center leading-relaxed">
+          Your calendar connection could not be restored. Please reconnect below.
+        </div>
+      )}
       <h3 className="text-base font-semibold text-primary">Choose your calendar source</h3>
       <p className="text-xs text-secondary max-w-sm text-center leading-relaxed">
         Tag calendar events with project hashtags (e.g. <code className="font-semibold text-primary">#myproject</code>) to assign them to projects.


### PR DESCRIPTION
## Summary

- Backend `restore()` and `get_source_config()` now return a `has_data` flag indicating whether the time-tracking DataFrame is actually loaded in memory
- Frontend gates the calendar grid view on `has_data` rather than config existence alone — shows the source chooser when data is absent
- Adds a "connection lost" banner in the source chooser when a previous config existed but data could not be restored

## Test plan

- [x] Configure a system calendar, verify it loads normally
- [x] Restart the app, verify the calendar restores and grid is shown
- [ ] Clear the parquet cache manually (`~/.tuttle/cache/timetracking_events.parquet`), reopen Time Tracking — should show source chooser with "connection lost" message
- [x] Import an ICS file, verify the banner disappears and grid shows

Closes #350

Made with [Cursor](https://cursor.com)