### PR TITLE
fix(dashboard): deduplicate planned revenue in bar chart

### DIFF
--- a/ui/src/components/dashboard/DashboardView.tsx
+++ b/ui/src/components/dashboard/DashboardView.tsx
@@ -87,6 +87,13 @@ export function DashboardView() {
       }
     }
 
+    // Deduplicate: calendar-derived planned revenue overlaps with
+    // invoice-based invoiced/pending for the same month.  Only show the
+    // portion not yet covered by invoices.
+    for (const bar of byLabel.values()) {
+      bar.planned = Math.max(0, bar.planned - bar.invoiced - bar.pending);
+    }
+
     const sorted = [...byLabel.values()].sort((a, b) => {
       const [am, ay] = a.label.split("/");
       const [bm, by] = b.label.split("/");


### PR DESCRIPTION
## Summary

- The revenue bar chart stacked `planned` (calendar-derived) on top of `invoiced`/`pending` (invoice-derived), double-counting revenue for months where tracked work had already been invoiced.
- After merging both data sources, `planned` is now reduced by the already-invoiced + pending amounts so only the uninvoiced portion is shown.

Closes #368

## Test plan

- [ ] Open dashboard with demo data containing both invoices and calendar events for the same months
- [ ] Verify that past months show invoiced/pending bars without inflated planned bars
- [ ] Verify that future months still show planned revenue from calendar data
- [ ] All 343 existing tests pass

Made with [Cursor](https://cursor.com)