### PR TITLE
Add optional payment due dates on invoice PDFs

### DIFF
--- a/templates/invoice-bold/invoice.html
+++ b/templates/invoice-bold/invoice.html
@@ -62,10 +62,12 @@
         <td class="meta-label">{{ l.date }}</td>
         <td class="meta-value">{{ invoice.date | as_date }}</td>
       </tr>
+      {% if include_due_date and invoice.effective_due_date %}
       <tr>
         <td class="meta-label">{{ l.due_date }}</td>
         <td class="meta-value">{{ invoice.effective_due_date | as_date }}</td>
       </tr>
+      {% endif %}
     </table>
   </div>
 

--- a/templates/invoice-grayshades/invoice.css
+++ b/templates/invoice-grayshades/invoice.css
@@ -106,6 +106,31 @@ body {
   margin-top: 0;
 }
 
+.meta-table {
+  border-collapse: collapse;
+  margin-bottom: 12pt;
+}
+
+.meta-table td {
+  padding: 1.5pt 0;
+  font-size: 8.5pt;
+  vertical-align: baseline;
+}
+
+.meta-label {
+  font-size: 7pt;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.8pt;
+  color: #4d4d4d;
+  padding-right: 12pt;
+  white-space: nowrap;
+}
+
+.meta-value {
+  color: #343434;
+}
+
 /* ── Items Table ─────────────────────────────── */
 
 .items-table {

--- a/templates/invoice-grayshades/invoice.html
+++ b/templates/invoice-grayshades/invoice.html
@@ -49,6 +49,19 @@
 
   <h1 class="invoice-title">{{ l.invoice_no }} {{ invoice.number }}</h1>
 
+  <table class="meta-table">
+    <tr>
+      <td class="meta-label">{{ l.date }}</td>
+      <td class="meta-value">{{ invoice.date | as_date }}</td>
+    </tr>
+    {% if include_due_date and invoice.effective_due_date %}
+    <tr>
+      <td class="meta-label">{{ l.due_date }}</td>
+      <td class="meta-value">{{ invoice.effective_due_date | as_date }}</td>
+    </tr>
+    {% endif %}
+  </table>
+
   <table class="items-table">
     <thead>
       <tr>

--- a/templates/invoice-minimal/invoice.html
+++ b/templates/invoice-minimal/invoice.html
@@ -63,10 +63,12 @@
       <td class="meta-label">{{ l.date }}</td>
       <td class="meta-value">{{ invoice.date | as_date }}</td>
     </tr>
+    {% if include_due_date and invoice.effective_due_date %}
     <tr>
       <td class="meta-label">{{ l.due_date }}</td>
       <td class="meta-value">{{ invoice.effective_due_date | as_date }}</td>
     </tr>
+    {% endif %}
   </table>
 
   <div class="divider thin"></div>

--- a/templates/invoice-modern/invoice.html
+++ b/templates/invoice-modern/invoice.html
@@ -64,10 +64,12 @@
       <td class="meta-label">{{ l.date }}</td>
       <td class="meta-value">{{ invoice.date | as_date }}</td>
     </tr>
+    {% if include_due_date and invoice.effective_due_date %}
     <tr>
       <td class="meta-label">{{ l.due_date }}</td>
       <td class="meta-value">{{ invoice.effective_due_date | as_date }}</td>
     </tr>
+    {% endif %}
   </table>
 
   <table class="items-table">

--- a/tuttle/app/invoicing/intent.py
+++ b/tuttle/app/invoicing/intent.py
@@ -367,6 +367,14 @@ class InvoicingIntent(Intent):
                     else True
                 )
 
+                due_date_result = self._preferences_intent.get_include_due_date()
+                resolved_include_due_date = (
+                    due_date_result.data
+                    if due_date_result.was_intent_successful
+                    and due_date_result.data is not None
+                    else True
+                )
+
                 try:
                     rendering.render_invoice(
                         user=user,
@@ -377,6 +385,7 @@ class InvoicingIntent(Intent):
                         language=language,
                         e_invoice_profile=e_invoice_profile,
                         include_logo=resolved_include_logo,
+                        include_due_date=resolved_include_due_date,
                         accent_color=user.accent_color or "",
                     )
                 except Exception as ex:
@@ -496,6 +505,23 @@ class InvoicingIntent(Intent):
                     )
                     if tmpl_result.was_intent_successful and tmpl_result.data:
                         resolved_template = tmpl_result.data
+
+                logo_result = self._preferences_intent.get_include_logo()
+                resolved_include_logo = (
+                    logo_result.data
+                    if logo_result.was_intent_successful
+                    and logo_result.data is not None
+                    else True
+                )
+
+                due_date_result = self._preferences_intent.get_include_due_date()
+                resolved_include_due_date = (
+                    due_date_result.data
+                    if due_date_result.was_intent_successful
+                    and due_date_result.data is not None
+                    else True
+                )
+
                 try:
                     rendering.render_invoice(
                         user=user,
@@ -504,6 +530,8 @@ class InvoicingIntent(Intent):
                         template_name=resolved_template,
                         only_final=True,
                         language=language,
+                        include_logo=resolved_include_logo,
+                        include_due_date=resolved_include_due_date,
                         accent_color=user.accent_color or "",
                     )
                     self._invoicing_data_source.save_invoice(reminder)
@@ -556,8 +584,7 @@ class InvoicingIntent(Intent):
                 )
 
             level_label = f"{'2nd ' if invoice.reminder_level == 2 else '3rd ' if invoice.reminder_level >= 3 else ''}reminder"
-            email_body = textwrap.dedent(
-                f"""\
+            email_body = textwrap.dedent(f"""\
 Dear {greeting},
 
 This is a {level_label} regarding the outstanding invoice {invoice.number} for {invoice.project.title}.
@@ -565,8 +592,7 @@ This is a {level_label} regarding the outstanding invoice {invoice.number} for {
 Please find attached the payment reminder.
 
 Best regards,
-{user.name}"""
-            )
+{user.name}""")
             mail.compose_email(
                 to=recipient,
                 subject=f"Payment Reminder: Invoice {invoice.number}",
@@ -620,15 +646,13 @@ Best regards,
                     error_msg="No contact email available for this client.",
                 )
 
-            email_body = textwrap.dedent(
-                f"""\
+            email_body = textwrap.dedent(f"""\
 Dear {greeting},
 
 Please find attached the invoice for {invoice.project.title}.
 
 Best regards,
-{user.name}"""
-            )
+{user.name}""")
             mail.compose_email(
                 to=recipient,
                 subject=f"Invoice {invoice.number}",

--- a/tuttle/app/preferences/intent.py
+++ b/tuttle/app/preferences/intent.py
@@ -10,6 +10,7 @@ from ..core.intent_result import IntentResult
 from ...app_db import AppDatabase
 from .model import (
     DEFAULT_E_INVOICE_PROFILE,
+    DEFAULT_INCLUDE_DUE_DATE,
     DEFAULT_INCLUDE_LOGO,
     DEFAULT_INVOICE_NUMBER_SCHEME,
     DEFAULT_INVOICE_TEMPLATE,
@@ -32,6 +33,14 @@ class PreferencesIntent:
             include_logo = DEFAULT_INCLUDE_LOGO
         else:
             include_logo = raw_include_logo == "true"
+
+        raw_include_due_date = self._app_db.get_setting(
+            PreferencesStorageKeys.include_due_date_key.value,
+        )
+        if raw_include_due_date is None:
+            include_due_date = DEFAULT_INCLUDE_DUE_DATE
+        else:
+            include_due_date = raw_include_due_date == "true"
 
         return IntentResult(
             was_intent_successful=True,
@@ -57,6 +66,7 @@ class PreferencesIntent:
                 )
                 or DEFAULT_E_INVOICE_PROFILE,
                 "include_logo": include_logo,
+                "include_due_date": include_due_date,
             },
         )
 
@@ -68,6 +78,7 @@ class PreferencesIntent:
         invoice_number_scheme=None,
         e_invoice_profile=None,
         include_logo=None,
+        include_due_date=None,
     ) -> IntentResult:
         if theme_mode is not None:
             self._app_db.set_setting(
@@ -99,6 +110,11 @@ class PreferencesIntent:
                 PreferencesStorageKeys.include_logo_key.value,
                 "true" if include_logo else "false",
             )
+        if include_due_date is not None:
+            self._app_db.set_setting(
+                PreferencesStorageKeys.include_due_date_key.value,
+                "true" if include_due_date else "false",
+            )
         return IntentResult(was_intent_successful=True, data=None)
 
     # -- Internal API (used by other intents) ----------------------------------
@@ -125,6 +141,16 @@ class PreferencesIntent:
         )
         if raw is None:
             include = DEFAULT_INCLUDE_LOGO
+        else:
+            include = raw == "true"
+        return IntentResult(was_intent_successful=True, data=include)
+
+    def get_include_due_date(self) -> IntentResult:
+        raw = self._app_db.get_setting(
+            PreferencesStorageKeys.include_due_date_key.value,
+        )
+        if raw is None:
+            include = DEFAULT_INCLUDE_DUE_DATE
         else:
             include = raw == "true"
         return IntentResult(was_intent_successful=True, data=include)

--- a/tuttle/app/preferences/model.py
+++ b/tuttle/app/preferences/model.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
 
-
 INVOICE_TEMPLATES = {
     "invoice-modern": "Modern",
     "invoice-minimal": "Minimal",
@@ -37,6 +36,8 @@ DEFAULT_E_INVOICE_PROFILE = "EN16931"
 
 DEFAULT_INCLUDE_LOGO = True
 
+DEFAULT_INCLUDE_DUE_DATE = True
+
 DEFAULT_THEME_MODE = "dark"
 
 
@@ -48,6 +49,7 @@ class Preferences:
     invoice_number_scheme: str = DEFAULT_INVOICE_NUMBER_SCHEME
     e_invoice_profile: str = DEFAULT_E_INVOICE_PROFILE
     include_logo: bool = DEFAULT_INCLUDE_LOGO
+    include_due_date: bool = DEFAULT_INCLUDE_DUE_DATE
 
 
 class PreferencesStorageKeys(Enum):
@@ -59,6 +61,7 @@ class PreferencesStorageKeys(Enum):
     invoice_number_scheme_key = "preferred_invoice_number_scheme"
     e_invoice_profile_key = "preferred_e_invoice_profile"
     include_logo_key = "preferred_include_logo"
+    include_due_date_key = "preferred_include_due_date"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/tuttle/rendering.py
+++ b/tuttle/rendering.py
@@ -153,6 +153,7 @@ def render_invoice(
     language: str = "en",
     e_invoice_profile: Optional[str] = None,
     include_logo: bool = True,
+    include_due_date: bool = True,
     accent_color: Optional[str] = None,
 ):
     """Render an Invoice using an HTML template.
@@ -236,6 +237,7 @@ def render_invoice(
         reminder_title=reminder_title,
         notes=invoice.notes,
         include_logo=include_logo,
+        include_due_date=include_due_date,
         accent_color=accent_color or "",
     )
     if out_dir is None:
@@ -309,11 +311,11 @@ def render_timesheet(
     template_env.filters["as_hours"] = lambda td: td / pandas.Timedelta("1 hour")
     template_env.filters["date"] = lambda dt: dt.strftime("%Y-%m-%d") if dt else ""
     template_env.filters["time"] = lambda dt: dt.strftime("%H:%M") if dt else ""
-    template_env.filters["datetime"] = (
-        lambda dt: dt.strftime("%Y-%m-%d %H:%M") if dt else ""
+    template_env.filters["datetime"] = lambda dt: (
+        dt.strftime("%Y-%m-%d %H:%M") if dt else ""
     )
-    template_env.filters["hours_minutes"] = (
-        lambda td: f"{int(td.total_seconds() // 3600)}:{int((td.total_seconds() % 3600) // 60):02d}"
+    template_env.filters["hours_minutes"] = lambda td: (
+        f"{int(td.total_seconds() // 3600)}:{int((td.total_seconds() % 3600) // 60):02d}"
         if td
         else ""
     )

--- a/tuttle_tests/test_rendering.py
+++ b/tuttle_tests/test_rendering.py
@@ -99,3 +99,34 @@ class TestRenderInvoice:
 
             dir = Path(out_dir) / Path(prefix)
             assert not dir.exists()
+
+    def test_due_date_shown_when_enabled(self, fake):
+        user = demo.create_fake_user(fake)
+        invoice = demo.create_fake_invoice(fake, render=False)
+        assert invoice.effective_due_date is not None
+
+        html = rendering.render_invoice(
+            user=user,
+            invoice=invoice,
+            out_dir=None,
+            document_format="html",
+            include_due_date=True,
+        )
+
+        assert "Due Date" in html
+        assert str(invoice.effective_due_date.year) in html
+
+    def test_due_date_hidden_when_disabled(self, fake):
+        user = demo.create_fake_user(fake)
+        invoice = demo.create_fake_invoice(fake, render=False)
+        assert invoice.effective_due_date is not None
+
+        html = rendering.render_invoice(
+            user=user,
+            invoice=invoice,
+            out_dir=None,
+            document_format="html",
+            include_due_date=False,
+        )
+
+        assert "Due Date" not in html

--- a/tuttle_tests/test_rpc_dispatch.py
+++ b/tuttle_tests/test_rpc_dispatch.py
@@ -20,7 +20,6 @@ import tuttle.app_db as app_db_mod
 from tuttle.app.core.dispatch import dispatch, _intents
 from tuttle.app.core.rpc_utils import reset_all
 
-
 # ---------------------------------------------------------------------------
 # Discover every RPC domain on disk: a subpackage of tuttle.app with intent.py
 # ---------------------------------------------------------------------------
@@ -122,6 +121,23 @@ class TestLifecycle:
         assert "email" in profile
         assert "address" in profile
         assert isinstance(profile["address"], dict)
+
+    def test_preferences_include_due_date_roundtrip(self, rpc_env):
+        save = dispatch(
+            "preferences.save",
+            {"include_due_date": False},
+        )
+        assert_ok(save)
+        data = dispatch("preferences.get", {})["data"]
+        assert data["include_due_date"] is False
+
+        save = dispatch(
+            "preferences.save",
+            {"include_due_date": True},
+        )
+        assert_ok(save)
+        data = dispatch("preferences.get", {})["data"]
+        assert data["include_due_date"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/ui/src/components/settings/SettingsView.tsx
+++ b/ui/src/components/settings/SettingsView.tsx
@@ -10,7 +10,7 @@
  * @see {@link ../layout/OnboardingWizard.tsx}
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Settings, RefreshCw, Save, CheckCircle2, AlertCircle, User, Bot, FileText, RotateCcw, Trash2, AlertTriangle, Monitor, Info, Image as ImageIcon, X, Sun, Moon, Laptop, Palette } from "lucide-react";
 import { useTheme, type ThemeChoice } from "../../hooks/useTheme";
 import { rpc } from "../../api/rpc";
@@ -75,6 +75,7 @@ interface InvoicingPrefs {
   invoice_number_scheme: string;
   e_invoice_profile: string;
   include_logo: boolean;
+  include_due_date: boolean;
 }
 
 const DEFAULT_INVOICING: InvoicingPrefs = {
@@ -83,6 +84,7 @@ const DEFAULT_INVOICING: InvoicingPrefs = {
   invoice_number_scheme: "daily",
   e_invoice_profile: "EN16931",
   include_logo: true,
+  include_due_date: true,
 };
 
 const SCHEME_EXAMPLES: Record<string, string> = {
@@ -138,8 +140,13 @@ export function SettingsView() {
   const [savedNotes, setSavedNotes] = useState<Entity[]>([]);
   const [newNoteText, setNewNoteText] = useState("");
   const [addingNote, setAddingNote] = useState(false);
+  const invoicingLoadRef = useRef(0);
 
-  useEffect(() => { loadConfig(); loadProfile(); loadInvoicingPrefs(); loadSupportedCountries(); loadSavedNotes(); }, []);
+  useEffect(() => { loadConfig(); loadProfile(); loadSupportedCountries(); loadSavedNotes(); }, []);
+
+  useEffect(() => {
+    if (tab === "invoicing") loadInvoicingPrefs();
+  }, [tab]);
 
   // -- LLM config ----------------------------------------------------------
 
@@ -305,6 +312,7 @@ export function SettingsView() {
   // -- Invoicing preferences -----------------------------------------------
 
   async function loadInvoicingPrefs() {
+    const loadId = ++invoicingLoadRef.current;
     const [prefsRes, tmplRes, langRes, schemeRes, eInvRes] = await Promise.all([
       rpc<InvoicingPrefs>("preferences.get"),
       rpc<Record<string, string>>("invoicing.available_templates"),
@@ -312,7 +320,10 @@ export function SettingsView() {
       rpc<Record<string, string>>("invoicing.available_number_schemes"),
       rpc<Record<string, string>>("invoicing.available_e_invoice_profiles"),
     ]);
-    if (prefsRes.ok && prefsRes.data) setInvoicing(prefsRes.data);
+    if (loadId !== invoicingLoadRef.current) return;
+    if (prefsRes.ok && prefsRes.data) {
+      setInvoicing({ ...DEFAULT_INVOICING, ...prefsRes.data });
+    }
     if (tmplRes.ok && tmplRes.data) setAvailableTemplates(tmplRes.data);
     if (langRes.ok && langRes.data) setAvailableLanguages(langRes.data);
     if (schemeRes.ok && schemeRes.data) setAvailableSchemes(schemeRes.data);
@@ -328,8 +339,14 @@ export function SettingsView() {
       invoice_number_scheme: invoicing.invoice_number_scheme,
       e_invoice_profile: invoicing.e_invoice_profile,
       include_logo: invoicing.include_logo,
+      include_due_date: invoicing.include_due_date,
     });
-    setInvoicingStatus(res.ok ? { type: "success", msg: "Invoicing preferences saved." } : { type: "error", msg: res.error || "Failed to save." });
+    if (res.ok) {
+      await loadInvoicingPrefs();
+      setInvoicingStatus({ type: "success", msg: "Invoicing preferences saved." });
+    } else {
+      setInvoicingStatus({ type: "error", msg: res.error || "Failed to save." });
+    }
     setInvoicingSaving(false);
   }
 
@@ -681,6 +698,17 @@ export function SettingsView() {
             <span className="text-sm text-primary">Include logo on invoices</span>
           </label>
           <p className="mt-1 text-xs text-muted mb-3">When enabled, your uploaded logo appears on generated invoices.</p>
+
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={invoicing.include_due_date}
+              onChange={(e) => setInvoicing((p) => ({ ...p, include_due_date: e.target.checked }))}
+              className="rounded border-border-subtle text-accent focus:ring-accent"
+            />
+            <span className="text-sm text-primary">Include payment due dates</span>
+          </label>
+          <p className="mt-1 text-xs text-muted mb-3">When enabled, a payment due date based on contract terms appears on generated invoices.</p>
 
           <div>
             <label className={labelCls}>Invoice language</label>


### PR DESCRIPTION
## Summary

Adds an "Include payment due dates" toggle in Settings → Invoicing (same pattern as "Include logo on invoices"). When enabled, contract-based due dates appear on generated invoice PDFs across all active templates (modern, minimal, bold, grayshades).
AI assistance (Cursor) was used to draft the implementation. I reviewed all changes, ran automated tests, and manually verified the toggle across invoice templates before submitting.
If anything doesn't match what was intended, happy to adjust — just let me know and I'll take a look.

## Checklist
- [x] I have read the [Contributing guide](../CONTRIBUTING.md).
- [x] I have installed and tested the application for my platform.
- [x] The test suite passes locally.
- [x] I understand and can explain all submitted changes; AI assistance disclosed above.

## UI/UX Updates

### Settings: Invoicing

<img width="1280" height="849" alt="1782894129682" src="https://github.com/user-attachments/assets/cad41aa3-d595-4063-8713-e82f58d105a0" />

