### PR TITLE
fix: use proper filename when downloading invoice and timesheet PDFs

### DIFF
--- a/ui/src/components/invoicing/InvoicingView.tsx
+++ b/ui/src/components/invoicing/InvoicingView.tsx
@@ -833,9 +833,20 @@ function InvoiceDetail({ invoice, allInvoices, onToggleSent, onTogglePaid, onTog
         <div className="flex-1 min-h-0 px-5 pb-5">
           {pdfLoading ? (
             <div className="flex items-center justify-center h-full text-secondary">Loading PDF…</div>
-          ) : pdfDataUrl ? (
-            <embed src={pdfDataUrl} type="application/pdf"
-              className="w-full h-full rounded-lg border border-border-subtle" />
+         ) : pdfDataUrl ? (
+            <div className="flex flex-col h-full gap-2">
+              <div className="flex justify-end">
+<a                
+                  href={pdfDataUrl}
+                  download={pdfPath.split(/[\\/]/).pop() ?? "invoice.pdf"}
+                  className="flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent/90 transition-colors"
+                >
+                  <FileText size={14} /> Download
+                </a>
+              </div>
+              <embed src={pdfDataUrl} type="application/pdf"
+                className="w-full flex-1 rounded-lg border border-border-subtle" />
+            </div>
           ) : (
             <div className="flex items-center justify-center h-full text-tertiary">
               PDF not available
@@ -852,8 +863,19 @@ function InvoiceDetail({ invoice, allInvoices, onToggleSent, onTogglePaid, onTog
           ) : tsPdfLoading ? (
             <div className="flex items-center justify-center h-full text-secondary">Loading PDF…</div>
           ) : tsPdfDataUrl ? (
-            <embed src={tsPdfDataUrl} type="application/pdf"
-              className="w-full h-full rounded-lg border border-border-subtle" />
+            <div className="flex flex-col h-full gap-2">
+              <div className="flex justify-end">
+<a                
+                  href={tsPdfDataUrl}
+                  download={tsPath.split(/[\\/]/).pop() ?? "timesheet.pdf"}
+                  className="flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent/90 transition-colors"
+                >
+                  <FileText size={14} /> Download
+                </a>
+              </div>
+              <embed src={tsPdfDataUrl} type="application/pdf"
+                className="w-full flex-1 rounded-lg border border-border-subtle" />
+            </div>
           ) : (
             <div className="flex flex-col items-center justify-center h-full gap-3 text-tertiary">
               <FileText size={36} strokeWidth={1.2} />

--- a/ui/src/components/invoicing/InvoicingView.tsx
+++ b/ui/src/components/invoicing/InvoicingView.tsx
@@ -853,7 +853,7 @@ function InvoiceDetail({ invoice, allInvoices, onToggleSent, onTogglePaid, onTog
             <div className="flex items-center justify-center h-full text-secondary">Loading PDF…</div>
          ) : pdfDataUrl ? (
               <embed src={pdfDataUrl} type="application/pdf"
-                className="w-full flex-1 rounded-lg border border-border-subtle" />
+  className="w-full h-full rounded-lg border border-border-subtle" />
           ) : (
             <div className="flex items-center justify-center h-full text-tertiary">
               PDF not available
@@ -871,7 +871,7 @@ function InvoiceDetail({ invoice, allInvoices, onToggleSent, onTogglePaid, onTog
             <div className="flex items-center justify-center h-full text-secondary">Loading PDF…</div>
           ) : tsPdfDataUrl ? (
               <embed src={tsPdfDataUrl} type="application/pdf"
-                className="w-full flex-1 rounded-lg border border-border-subtle" />
+  className="w-full h-full rounded-lg border border-border-subtle" />
           ) : (
             <div className="flex flex-col items-center justify-center h-full gap-3 text-tertiary">
               <FileText size={36} strokeWidth={1.2} />

--- a/ui/src/components/invoicing/InvoicingView.tsx
+++ b/ui/src/components/invoicing/InvoicingView.tsx
@@ -781,6 +781,24 @@ function InvoiceDetail({ invoice, allInvoices, onToggleSent, onTogglePaid, onTog
                 <AlertTriangle size={13} /> Create Reminder
               </button>
             )}
+            {!isCancelled && pdfPath && (
+  <a
+    href={pdfDataUrl ?? ""}
+    download={(pdfPath.split(/[\\/]/).pop() ?? "invoice.pdf").replace(/[<>:"/\\|?*]+/g, "_")}
+    className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-accent text-white hover:bg-accent/90 transition-colors"
+  >
+    <FileText size={13} /> Download Invoice
+  </a>
+)}
+{!isCancelled && tsPdfDataUrl && (
+  <a
+    href={tsPdfDataUrl}
+    download={(tsPath.split(/[\\/]/).pop() ?? "timesheet.pdf").replace(/[<>:"/\\|?*]+/g, "_")}
+    className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-accent text-white hover:bg-accent/90 transition-colors"
+  >
+    <FileText size={13} /> Download Timesheet
+  </a>
+)}
             <div className="flex-1" />
             {!isCancelled && (
               <>
@@ -834,19 +852,8 @@ function InvoiceDetail({ invoice, allInvoices, onToggleSent, onTogglePaid, onTog
           {pdfLoading ? (
             <div className="flex items-center justify-center h-full text-secondary">Loading PDF…</div>
          ) : pdfDataUrl ? (
-            <div className="flex flex-col h-full gap-2">
-              <div className="flex justify-end">
-<a                
-                  href={pdfDataUrl}
-                  download={pdfPath.split(/[\\/]/).pop() ?? "invoice.pdf"}
-                  className="flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent/90 transition-colors"
-                >
-                  <FileText size={14} /> Download
-                </a>
-              </div>
               <embed src={pdfDataUrl} type="application/pdf"
                 className="w-full flex-1 rounded-lg border border-border-subtle" />
-            </div>
           ) : (
             <div className="flex items-center justify-center h-full text-tertiary">
               PDF not available
@@ -863,19 +870,8 @@ function InvoiceDetail({ invoice, allInvoices, onToggleSent, onTogglePaid, onTog
           ) : tsPdfLoading ? (
             <div className="flex items-center justify-center h-full text-secondary">Loading PDF…</div>
           ) : tsPdfDataUrl ? (
-            <div className="flex flex-col h-full gap-2">
-              <div className="flex justify-end">
-<a                
-                  href={tsPdfDataUrl}
-                  download={tsPath.split(/[\\/]/).pop() ?? "timesheet.pdf"}
-                  className="flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent/90 transition-colors"
-                >
-                  <FileText size={14} /> Download
-                </a>
-              </div>
               <embed src={tsPdfDataUrl} type="application/pdf"
                 className="w-full flex-1 rounded-lg border border-border-subtle" />
-            </div>
           ) : (
             <div className="flex flex-col items-center justify-center h-full gap-3 text-tertiary">
               <FileText size={36} strokeWidth={1.2} />


### PR DESCRIPTION
## Summary

Fixes #366

When downloading a PDF via the embedded viewer, the file was saved as `download.pdf` instead of the document's actual filename. This happened because the viewer uses a `data:` URL (base64-encoded), which carries no filename information.

**Fix:** Added a Download button above both the invoice and timesheet PDF viewers using an `<a>` tag with the `download` attribute set to the actual filename extracted from `pdfPath` / `tsPath`.

## Screenshots

### Invoice PDF
<img width="1775" height="1117" alt="image" src="https://github.com/user-attachments/assets/c02d41f7-781f-4a31-97b2-8eb260af8b3d" />




### Download dialog
<img width="1782" height="1127" alt="image" src="https://github.com/user-attachments/assets/cb4da673-bb66-4b2b-8fa2-6d6ae15001db" />





> Note: I wasn't able to provide a screenshot for the timesheet view because the demo data doesn't include an invoice with an associated timesheet. The same download logic has been implemented for both invoice and timesheet PDFs.

> AI assistance disclosure: I used AI assistance to help identify the root cause and structure the fix. I reviewed and understood all submitted changes.

## Checklist
- [x] I have read the Contributing guide.
- [x] I have installed and tested the application for my platform (`just dev`).
- [ ] The test suite passes locally (`just test`).
- [ ] Pre-commit hooks are installed and pass (`just precommit`).
- [ ] I have added or updated tests where appropriate.
- [ ] I have updated the documentation / docstrings where appropriate.
- [ ] If my change touches the schema (`tuttle/model.py`), I generated and reviewed an Alembic migration (`just migrate "<msg>"`).
- [x] If my change affects the graphical user interface, I have provided screenshots.
- [x] I understand and can explain all submitted changes; if AI assistance was significant, I have disclosed it in the summary above..

**Update (following reviewer feedback):**
- Moved Download Invoice and Download Timesheet buttons to the existing Actions section alongside other action buttons
- Added filename sanitization to replace special characters with underscores, ensuring valid filenames across all platforms