### PR TITLE
ci: macOS code signing and notarization for releases

### DIFF
--- a/.github/workflows/pack-electron.yml
+++ b/.github/workflows/pack-electron.yml
@@ -66,8 +66,13 @@ jobs:
       run: npx electron-builder --publish ${{ startsWith(github.ref, 'refs/tags/') && 'always' || 'never' }}
       working-directory: ui
       env:
-        CSC_IDENTITY_AUTO_DISCOVERY: "false"
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CSC_IDENTITY_AUTO_DISCOVERY: ${{ startsWith(github.ref, 'refs/tags/') && 'true' || 'false' }}
+        CSC_LINK: ${{ startsWith(github.ref, 'refs/tags/') && secrets.CSC_LINK || '' }}
+        CSC_KEY_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/') && secrets.CSC_KEY_PASSWORD || '' }}
+        APPLE_ID: ${{ startsWith(github.ref, 'refs/tags/') && secrets.APPLE_ID || '' }}
+        APPLE_APP_SPECIFIC_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/') && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+        APPLE_TEAM_ID: ${{ startsWith(github.ref, 'refs/tags/') && secrets.APPLE_TEAM_ID || '' }}
 
     # Artifacts (skip on merge-queue validation runs)
     - uses: actions/upload-artifact@v7

--- a/ui/build/entitlements.mac.plist
+++ b/ui/build/entitlements.mac.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key><true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key><true/>
+</dict>
+</plist>

--- a/ui/package.json
+++ b/ui/package.json
@@ -44,8 +44,14 @@
     },
     "mac": {
       "artifactName": "Tuttle-${version}-macOS-${arch}.${ext}",
-      "identity": "-",
       "category": "public.app-category.business",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
+      "notarize": {
+        "teamId": "4F26A7M64F"
+      },
       "target": [
         "zip",
         "dmg"


### PR DESCRIPTION
## Summary
- Configure electron-builder for real code signing + notarization on tag pushes (releases)
- Non-tag pushes to main continue using ad-hoc signing
- Add hardened runtime entitlements for PyInstaller sidecar compatibility

Closes #320

## Test plan
- [x] Merge to main → CI builds with ad-hoc signing (no change in behavior)
- [ ] Push a tag (`just release patch`) → CI signs + notarizes → download .dmg and verify with `spctl --assess`

