### PR TITLE
fix(timetracking): crash on tz-aware calendar data + view error boundary

### DIFF
--- a/tuttle/app/timetracking/aggregation.py
+++ b/tuttle/app/timetracking/aggregation.py
@@ -28,7 +28,7 @@ def df_to_records(df: DataFrame, tag_to_workday: Optional[dict] = None) -> list:
     if df is None or df.empty:
         return []
     tag_to_workday = tag_to_workday or {}
-    now = datetime.datetime.now()
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
     records = []
     for idx, row in df.iterrows():
         begin = idx
@@ -41,6 +41,15 @@ def df_to_records(df: DataFrame, tag_to_workday: Optional[dict] = None) -> list:
         tag = str(row.get("tag", ""))
         workday = tag_to_workday.get(tag, DEFAULT_WORKDAY_HOURS)
         dur_hours = event_hours(row, workday)
+        if begin_dt is not None:
+            cmp_dt = (
+                begin_dt
+                if begin_dt.tzinfo
+                else begin_dt.replace(tzinfo=datetime.timezone.utc)
+            )
+            is_future = cmp_dt >= now
+        else:
+            is_future = False
         records.append(
             {
                 "begin": str(begin),
@@ -51,7 +60,7 @@ def df_to_records(df: DataFrame, tag_to_workday: Optional[dict] = None) -> list:
                 "description": str(row.get("description", "") or ""),
                 "all_day": bool(row.get("all_day", False)),
                 "date": str(begin)[:10],
-                "is_future": begin_dt >= now if begin_dt else False,
+                "is_future": is_future,
             }
         )
     return records
@@ -122,8 +131,11 @@ def build_calendar_data(
 
     total_hours = total_event_hours(month_df, tag_to_workday) if len(month_df) else 0
 
-    today = datetime.date.today()
-    future_mask = month_df.index.date >= today
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    if hasattr(month_df.index, "tz") and month_df.index.tz is not None:
+        future_mask = month_df.index >= now
+    else:
+        future_mask = month_df.index >= now.replace(tzinfo=None)
     future_df = month_df[future_mask]
     planned_hours = (
         total_event_hours(future_df, tag_to_workday) if len(future_df) else 0

--- a/tuttle_tests/test_timetracking.py
+++ b/tuttle_tests/test_timetracking.py
@@ -256,3 +256,72 @@ def test_generate_timesheet_preserves_per_event_descriptions():
     assert items["Meeting"].description == "Notes from meeting"
     # Row with no description gets the fallback.
     assert items["Deep work"].description == "Fallback description"
+
+
+# ---------------------------------------------------------------------------
+# Aggregation regression tests — tz-aware data (real ICS imports)
+# ---------------------------------------------------------------------------
+
+
+def test_df_to_records_with_tz_aware_data():
+    """Regression: df_to_records must not crash on tz-aware timestamps.
+
+    ICS calendar imports produce CET-localized Timestamps. A naive
+    datetime.now() comparison causes TypeError.
+    """
+    from tuttle.app.timetracking.aggregation import df_to_records
+
+    begin = pandas.to_datetime(
+        ["2026-07-01 09:00:00", "2026-12-01 09:00:00"], utc=True
+    ).tz_convert("CET")
+    end = pandas.to_datetime(
+        ["2026-07-01 11:00:00", "2026-12-01 11:00:00"], utc=True
+    ).tz_convert("CET")
+
+    df = pandas.DataFrame(
+        {
+            "end": end,
+            "title": ["Past event", "Future event"],
+            "tag": ["#proj", "#proj"],
+            "description": ["", ""],
+            "all_day": [False, False],
+        },
+        index=pandas.Index(begin, name="begin"),
+    )
+    df["duration"] = df["end"] - df.index
+
+    records = df_to_records(df)
+    assert len(records) == 2
+    assert records[0]["is_future"] is False
+    assert records[1]["is_future"] is True
+
+
+def test_build_calendar_data_with_tz_aware_data():
+    """Regression: build_calendar_data must handle tz-aware DataFrames."""
+    from tuttle.app.timetracking.aggregation import build_calendar_data
+
+    begin = pandas.to_datetime(
+        ["2026-07-03 09:00:00", "2026-07-04 14:00:00"], utc=True
+    ).tz_convert("CET")
+    end = pandas.to_datetime(
+        ["2026-07-03 11:00:00", "2026-07-04 16:00:00"], utc=True
+    ).tz_convert("CET")
+
+    df = pandas.DataFrame(
+        {
+            "end": end,
+            "title": ["Task A", "Task B"],
+            "tag": ["#alpha", "#beta"],
+            "description": ["", ""],
+            "all_day": [False, False],
+        },
+        index=pandas.Index(begin, name="begin"),
+    )
+    df["duration"] = df["end"] - df.index
+
+    result = build_calendar_data(df, 2026, 7)
+    assert result["year"] == 2026
+    assert result["month"] == 7
+    assert result["summary"]["total_events"] == 2
+    assert result["summary"]["total_hours"] > 0
+    assert len(result["events"]) == 2

--- a/ui/src/components/layout/Shell.tsx
+++ b/ui/src/components/layout/Shell.tsx
@@ -14,6 +14,7 @@ import { SalaryView } from "../salary/SalaryView";
 import { TimeTrackingView } from "../timetracking/TimeTrackingView";
 import { DocumentImportView } from "../import/DocumentImportView";
 import { PlaceholderView } from "../shared/PlaceholderView";
+import { ViewErrorBoundary } from "../shared/ViewErrorBoundary";
 import { UpdateBanner } from "./UpdateBanner";
 import { StatusBar } from "./StatusBar";
 import { StatusBarProvider } from "../shared/status-bar-context";
@@ -206,7 +207,9 @@ export function Shell() {
               <div className="drag-region h-13 shrink-0" />
               <UpdateBanner />
               <div className="flex-1 overflow-y-auto">
-                <DetailView id={selected} />
+                <ViewErrorBoundary key={selected} viewName={selected}>
+                  <DetailView id={selected} />
+                </ViewErrorBoundary>
               </div>
               <StatusBar />
             </main>

--- a/ui/src/components/shared/ViewErrorBoundary.tsx
+++ b/ui/src/components/shared/ViewErrorBoundary.tsx
@@ -1,0 +1,113 @@
+import { Component, type ReactNode } from "react";
+import { AlertTriangle, Copy, RotateCcw } from "lucide-react";
+
+interface Props {
+  viewName?: string;
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+  errorInfo: React.ErrorInfo | null;
+  copied: boolean;
+}
+
+export class ViewErrorBoundary extends Component<Props, State> {
+  state: State = { error: null, errorInfo: null, copied: false };
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    this.setState({ errorInfo });
+  }
+
+  private handleRetry = () => {
+    this.setState({ error: null, errorInfo: null, copied: false });
+  };
+
+  private handleCopy = async () => {
+    const report = this.buildReport();
+    try {
+      await navigator.clipboard.writeText(report);
+      this.setState({ copied: true });
+      setTimeout(() => this.setState({ copied: false }), 2000);
+    } catch {
+      // fallback: select a textarea (not needed in Electron, but safe)
+    }
+  };
+
+  private buildReport(): string {
+    const { error, errorInfo } = this.state;
+    const lines = [
+      `## Error Report — ${this.props.viewName || "View"}`,
+      "",
+      `**Error:** ${error?.message || "Unknown error"}`,
+      "",
+      "**Stack:**",
+      "```",
+      error?.stack || "(no stack trace)",
+      "```",
+      "",
+      "**Component Stack:**",
+      "```",
+      errorInfo?.componentStack?.trim() || "(unavailable)",
+      "```",
+      "",
+      `**Timestamp:** ${new Date().toISOString()}`,
+      `**User Agent:** ${navigator.userAgent}`,
+    ];
+    return lines.join("\n");
+  }
+
+  render() {
+    if (!this.state.error) {
+      return this.props.children;
+    }
+
+    const { error } = this.state;
+    const viewLabel = this.props.viewName || "This view";
+
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-5 px-6">
+        <div className="flex flex-col items-center gap-3 max-w-md text-center">
+          <div className="w-12 h-12 rounded-2xl bg-red-500/10 flex items-center justify-center">
+            <AlertTriangle size={24} strokeWidth={1.5} className="text-red-400" />
+          </div>
+
+          <h3 className="text-base font-semibold text-primary">
+            {viewLabel} encountered an error
+          </h3>
+
+          <p className="text-xs text-secondary leading-relaxed">
+            Something went wrong while rendering this view. You can retry, or copy the error details below to include in a bug report.
+          </p>
+
+          <div className="w-full mt-2 rounded-lg border border-border-subtle bg-bg-card p-3 text-left">
+            <p className="text-xs font-mono text-red-400 break-all leading-relaxed">
+              {error.message}
+            </p>
+          </div>
+
+          <div className="flex gap-2 mt-3">
+            <button
+              onClick={this.handleRetry}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium text-primary bg-bg-card border border-border-subtle hover:bg-bg-hover transition-colors"
+            >
+              <RotateCcw size={12} />
+              Retry
+            </button>
+            <button
+              onClick={this.handleCopy}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium text-white bg-accent hover:bg-accent/90 transition-colors"
+            >
+              <Copy size={12} />
+              {this.state.copied ? "Copied!" : "Copy error report"}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/ui/src/components/timetracking/TimeTrackingView.tsx
+++ b/ui/src/components/timetracking/TimeTrackingView.tsx
@@ -260,7 +260,7 @@ export function TimeTrackingView() {
           ) : (
             <>
               {/* Re-import strip — shows only the active source */}
-              {calendarSource === "ics" && (
+              {calData && calendarSource === "ics" && (
                 <div
                   className={`mx-5 mt-4 flex items-center gap-3 rounded-lg border border-dashed p-2.5 transition-colors ${dragOver ? "border-accent bg-accent/10" : "border-border-subtle"}`}
                   onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
@@ -276,6 +276,7 @@ export function TimeTrackingView() {
               )}
 
               {/* Month navigation + grid */}
+              {calData && (
               <div className="px-5 pt-4 pb-4">
                 <div className="flex items-center gap-3 mb-4">
                   <button onClick={prevMonth} className="p-1.5 rounded-md hover:bg-bg-hover text-primary"><ChevronLeft size={18} /></button>
@@ -313,9 +314,10 @@ export function TimeTrackingView() {
                   onSelectDay={setSelectedDay}
                 />
               </div>
+              )}
 
               {/* Day detail */}
-              {selectedDay && (
+              {selectedDay && calData && (
                 <DayDetail
                   day={selectedDay}
                   events={dayEvents}


### PR DESCRIPTION
## Summary

- **Fix**: `df_to_records()` and `build_calendar_data()` crashed with `TypeError: can't compare offset-naive and offset-aware datetimes` when processing real ICS calendar data (which is CET-localized). This was introduced in #373 which changed the is_future comparison from date-granularity to datetime-granularity but used naive `datetime.now()`. Fixed by using `datetime.now(tz=timezone.utc)` and handling both tz-aware and naive DataFrames.
- **Error boundary**: Added `ViewErrorBoundary` wrapping all views so any render crash shows a user-reportable error message (with copy-to-clipboard) instead of a blank screen.
- **Regression tests**: Two new tests (`test_df_to_records_with_tz_aware_data`, `test_build_calendar_data_with_tz_aware_data`) exercise the aggregation layer with CET-localized timestamps matching real ICS imports.

## Test plan

- [x] `uv run pytest` passes (354 tests)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Manual: import a real `.ics` file → time tracking view renders correctly
- [ ] Manual: simulate a render crash → error boundary shows message with "Copy error report" button


Made with [Cursor](https://cursor.com)