### PR TITLE
ci: only publish release assets after all platforms succeed

### DIFF
--- a/.github/workflows/pack-electron.yml
+++ b/.github/workflows/pack-electron.yml
@@ -62,9 +62,9 @@ jobs:
     - name: Build Electron app
       run: npm run build
       working-directory: ui
-    - name: Package Electron app (signed release)
-      if: startsWith(github.ref, 'refs/tags/')
-      run: npx electron-builder --publish always
+    - name: Package Electron app (signed)
+      if: startsWith(github.ref, 'refs/tags/') && runner.os == 'macOS'
+      run: npx electron-builder --publish never
       working-directory: ui
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,16 +74,36 @@ jobs:
         APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
     - name: Package Electron app (unsigned)
-      if: "!startsWith(github.ref, 'refs/tags/')"
+      if: "!(startsWith(github.ref, 'refs/tags/') && runner.os == 'macOS')"
       run: npx electron-builder --publish never
       working-directory: ui
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CSC_IDENTITY_AUTO_DISCOVERY: "false"
 
-    # Artifacts (skip on merge-queue validation runs)
     - uses: actions/upload-artifact@v7
       if: github.event_name != 'merge_group'
       with:
         name: Tuttle-${{ github.ref_name }}-${{ matrix.platform }}
         path: ui/release/
+
+  # Upload artifacts to GitHub Release only after ALL platforms succeed
+  publish:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download all artifacts
+      uses: actions/download-artifact@v7
+      with:
+        path: artifacts/
+    - name: Upload release assets
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        tag="${GITHUB_REF#refs/tags/}"
+        for f in artifacts/**/*.{dmg,zip,exe,deb,rpm,AppImage,yml,blockmap}; do
+          [ -f "$f" ] || continue
+          echo "Uploading: $f"
+          gh release upload "$tag" "$f" --repo "$GITHUB_REPOSITORY" --clobber
+        done


### PR DESCRIPTION
## Summary
- All platform builds now use `--publish never` (no direct upload to release)
- New `publish` job runs only after all build jobs succeed
- If any platform fails, no assets are attached to the release — no more silent partial releases

## Test plan
- [ ] Push to main → builds run, no publish job (not a tag)
- [ ] Tag push → all builds pass → publish job uploads all assets
- [ ] If one build fails → publish job is skipped → release has no (partial) assets

Made with [Cursor](https://cursor.com)