### PR TITLE
fix(invoice): normalize VAT rate on imported invoices

### DIFF
--- a/tuttle/app/imports/intent.py
+++ b/tuttle/app/imports/intent.py
@@ -13,7 +13,16 @@ from loguru import logger
 from ..core.abstractions import SQLModelDataSourceMixin
 from ..core.intent_result import IntentResult
 from ...data_dir import get_data_dir
-from ...model import Address, Contact, Client, Contract, Project, Invoice, InvoiceItem
+from ...model import (
+    Address,
+    Contact,
+    Client,
+    Contract,
+    Project,
+    Invoice,
+    InvoiceItem,
+    normalize_vat_rate,
+)
 from ...time import ContractType
 
 
@@ -233,6 +242,33 @@ def _validate_import_data(data: dict) -> List[str]:
                     f'Invoice "{inv_label}" item #{idx}: missing {", ".join(missing)}'
                 )
 
+            # Plausibility: VAT rate must be a valid fraction
+            vat = fields.get("VAT_rate")
+            if vat is not None:
+                try:
+                    normalized = normalize_vat_rate(vat)
+                    if normalized > Decimal("0.30"):
+                        errors.append(
+                            f'Invoice "{inv_label}" item #{idx}: '
+                            f"VAT rate {float(normalized):.0%} seems implausibly high"
+                        )
+                except ValueError as e:
+                    errors.append(
+                        f'Invoice "{inv_label}" item #{idx}: invalid VAT rate — {e}'
+                    )
+
+            # Plausibility: unit_price and quantity must be positive
+            unit_price = fields.get("unit_price")
+            if unit_price is not None and Decimal(str(unit_price)) < 0:
+                errors.append(
+                    f'Invoice "{inv_label}" item #{idx}: unit price is negative'
+                )
+            qty = fields.get("quantity")
+            if qty is not None and float(qty) <= 0:
+                errors.append(
+                    f'Invoice "{inv_label}" item #{idx}: quantity must be positive'
+                )
+
     return errors
 
 
@@ -447,10 +483,12 @@ def _save_invoice(
     session.add(invoice)
     session.flush()
 
-    # Create line items
     for li_data in line_items_data:
         li_fields = _model_fields(li_data, InvoiceItem)
         li_fields["invoice_id"] = invoice.id
+        vat = li_fields.get("VAT_rate")
+        if vat is not None:
+            li_fields["VAT_rate"] = normalize_vat_rate(vat)
         line_item = InvoiceItem(**li_fields)
         session.add(line_item)
 

--- a/tuttle/llm.py
+++ b/tuttle/llm.py
@@ -863,18 +863,28 @@ def _map_document_extraction(
 
 def _map_invoices(invoices: list) -> List[Dict[str, Any]]:
     """Map extracted invoice objects to dicts for the frontend."""
+    from .model import normalize_vat_rate
+
     results = []
     for inv in invoices:
         d = inv.model_dump()
         for k in list(d):
             if k.endswith("_date"):
                 d[k] = _serialise_date(d[k])
-        # Serialise nested items' dates
         items = d.get("items", [])
         for item in items:
             for k in list(item):
                 if k.endswith("_date"):
                     item[k] = _serialise_date(item[k])
+            vat = item.get("VAT_rate")
+            if vat is not None:
+                try:
+                    item["VAT_rate"] = float(normalize_vat_rate(vat))
+                except ValueError as e:
+                    logger.warning(
+                        f"LLM extraction returned invalid invoice item VAT rate {vat!r}: {e}"
+                    )
+                    item["VAT_rate"] = None
         if _has_content(d, ignore={"ref", "items"}):
             results.append(d)
         elif items and any(_has_content(i) for i in items):

--- a/tuttle/model.py
+++ b/tuttle/model.py
@@ -31,6 +31,7 @@ import pandas
 import sqlalchemy
 
 from pydantic import BaseModel, condecimal, validator
+from sqlalchemy.orm import validates
 from sqlmodel import SQLModel, Field, Relationship
 
 
@@ -601,9 +602,9 @@ class Contract(RpcMixin, SQLModel, table=True):
                 raise ValueError("A time-based contract needs a rate.")
             self.fixed_price = None
 
-    # NOTE: VAT_rate normalisation lives in ``ContractsIntent._validated_save``
-    # and ``normalize_vat_rate`` is used on every ingress (LLM mapping,
-    # manual scripts).
+    @validates("VAT_rate")
+    def _normalize_vat_rate(self, _key, value):
+        return normalize_vat_rate(value)
 
 
 class Project(RpcMixin, SQLModel, table=True):
@@ -1113,6 +1114,10 @@ class InvoiceItem(RpcMixin, SQLModel, table=True):
     @property
     def unit_price_formatted(self) -> str:
         return fmt_currency(self.unit_price)
+
+    @validates("VAT_rate")
+    def _normalize_vat_rate(self, _key, value):
+        return normalize_vat_rate(value)
 
     @property
     def VAT(self) -> Decimal:

--- a/tuttle_tests/test_document_import.py
+++ b/tuttle_tests/test_document_import.py
@@ -296,6 +296,99 @@ class TestInvoiceImport:
         result = intent.commit_import(data)
         assert result.was_intent_successful
 
+    def test_vat_rate_percent_normalized_on_save(self, in_memory_db):
+        """VAT_rate given as percent (e.g. 19) is normalized to 0.19 in the DB."""
+        intent = ImportsIntent()
+        data = {
+            "contacts": [],
+            "clients": [],
+            "contracts": [],
+            "projects": [],
+            "invoices": [
+                {
+                    "ref": "inv_1",
+                    "number": "VAT-PCT-001",
+                    "date": "2024-06-01",
+                    "contract_ref": "",
+                    "project_ref": "",
+                    "items": [
+                        {
+                            "description": "Consulting",
+                            "quantity": 10.0,
+                            "unit": "hour",
+                            "unit_price": 100.0,
+                            "VAT_rate": 19,
+                        }
+                    ],
+                }
+            ],
+        }
+
+        result = intent.commit_import(data)
+        assert result.was_intent_successful
+
+        with Session(in_memory_db) as session:
+            item = session.exec(select(InvoiceItem)).one()
+            assert item.VAT_rate == Decimal("0.19")
+            assert item.subtotal == Decimal("1000")
+            assert item.VAT == Decimal("190.0")
+
+    def test_validation_catches_implausible_vat_rate(self, in_memory_db):
+        """A VAT rate above 30% triggers a plausibility warning."""
+        from tuttle.app.imports.intent import _validate_import_data
+
+        data = {
+            "contacts": [],
+            "clients": [],
+            "contracts": [],
+            "projects": [],
+            "invoices": [
+                {
+                    "number": "BAD-VAT",
+                    "date": "2024-01-01",
+                    "items": [
+                        {
+                            "description": "Item",
+                            "quantity": 1.0,
+                            "unit": "hour",
+                            "unit_price": 100.0,
+                            "VAT_rate": 0.50,
+                        }
+                    ],
+                }
+            ],
+        }
+        errors = _validate_import_data(data)
+        assert any("implausibly high" in e for e in errors)
+
+    def test_validation_catches_negative_unit_price(self, in_memory_db):
+        """Negative unit price is flagged."""
+        from tuttle.app.imports.intent import _validate_import_data
+
+        data = {
+            "contacts": [],
+            "clients": [],
+            "contracts": [],
+            "projects": [],
+            "invoices": [
+                {
+                    "number": "NEG-001",
+                    "date": "2024-01-01",
+                    "items": [
+                        {
+                            "description": "Credit?",
+                            "quantity": 1.0,
+                            "unit": "piece",
+                            "unit_price": -50.0,
+                            "VAT_rate": 0.19,
+                        }
+                    ],
+                }
+            ],
+        }
+        errors = _validate_import_data(data)
+        assert any("negative" in e for e in errors)
+
 
 class TestClientAddressImport:
     """Regression guard: client address extraction must persist an Address row."""
@@ -515,6 +608,29 @@ class TestLlmInvoiceSchema:
         assert len(result[0]["items"]) == 1
         assert result[0]["items"][0]["quantity"] == 10.0
         assert result[0]["items"][0]["start_date"] == "2024-06-01"
+
+    def test_map_invoices_normalizes_vat_rate_percent(self):
+        """LLM returning VAT_rate as percent (e.g. 19) must be normalized to fraction."""
+        from tuttle.llm import _map_invoices, _RefInvoice, _RefInvoiceItem
+
+        inv = _RefInvoice(
+            ref="inv_1",
+            number="PCT-001",
+            date=datetime.date(2024, 1, 1),
+            items=[
+                _RefInvoiceItem(
+                    quantity=1.0,
+                    unit="hour",
+                    unit_price=100.0,
+                    description="Work",
+                    VAT_rate=19,
+                )
+            ],
+        )
+
+        result = _map_invoices([inv])
+        vat = result[0]["items"][0]["VAT_rate"]
+        assert abs(vat - 0.19) < 1e-6, f"Expected 0.19, got {vat}"
 
     def test_summary_prompt_includes_invoices(self):
         """Verify the generated summary prompt mentions invoices."""


### PR DESCRIPTION
## Summary

- **Root cause**: The LLM document parser could return `VAT_rate` as a percent (e.g. `19`) instead of a fraction (`0.19`). Contracts already normalized via `normalize_vat_rate()`, but invoice line items did not — producing absurd VAT totals (e.g. 1900%).
- **Fix**: Normalize `VAT_rate` on invoice items at three layers: LLM extraction mapping (`_map_invoices`), DB persistence (`_save_invoice`), and SQLAlchemy attribute validation (`@validates` on `InvoiceItem` and `Contract`).
- **Plausibility checks**: Added validation in `_validate_import_data()` that flags implausibly high VAT rates (>30%), negative unit prices, and non-positive quantities before an import can be committed.

## Test plan

- [x] `test_map_invoices_normalizes_vat_rate_percent` — LLM extraction normalizes `19` → `0.19`
- [x] `test_vat_rate_percent_normalized_on_save` — DB persistence normalizes and produces correct VAT amounts
- [x] `test_validation_catches_implausible_vat_rate` — 50% VAT is flagged
- [x] `test_validation_catches_negative_unit_price` — negative prices are flagged
- [x] Full test suite: 357 passed, 0 failures
- [ ] Manual: import an invoice PDF via AI document parsing and verify VAT calculation

Closes #380

Made with [Cursor](https://cursor.com)