### PR TITLE
fix: replace unit text input with dropdown in document import view

### DIFF
--- a/ui/src/components/import/DocumentImportView.tsx
+++ b/ui/src/components/import/DocumentImportView.tsx
@@ -113,6 +113,8 @@ function makeSteps(upTo: number, running: number): ImportStep[] {
 // Main View
 // ---------------------------------------------------------------------------
 
+const UNIT_OPTIONS = ["hour", "day", "piece", "flat"] as const;
+
 export function DocumentImportView() {
   const [phase, setPhase] = useState<Phase>("upload");
   const [parsing, setParsing] = useState(false);
@@ -780,8 +782,11 @@ function InvoiceCard({ item, onUpdate, importedContracts, importedProjects, exis
                 <label className="block text-[10px] text-tertiary mb-0.5">
                   Unit{ireq("unit") && <span className="text-red-400 ml-0.5">*</span>}
                 </label>
-                <input value={li.unit} onChange={(e) => updateItem(idx, "unit", e.target.value)}
-                  className={`w-full px-2 py-1 rounded text-xs bg-bg-card text-primary border ${borderCls("unit", li.unit)} outline-none focus:border-fuchsia-400`} />
+                <select value={li.unit ?? ""} onChange={(e) => updateItem(idx, "unit", e.target.value)}
+                  className={`w-full px-2 py-1 rounded text-xs bg-bg-card text-primary border ${borderCls("unit", li.unit)} outline-none focus:border-fuchsia-400`}>
+                  <option value="" disabled>Select unit</option>
+                  {UNIT_OPTIONS.map((u) => <option key={u} value={u}>{u}</option>)}
+                </select>
               </div>
               <div>
                 <label className="block text-[10px] text-tertiary mb-0.5">

--- a/ui/src/components/import/DocumentImportView.tsx
+++ b/ui/src/components/import/DocumentImportView.tsx
@@ -6,6 +6,7 @@ import {
   XCircle, Receipt, Plus, Minus,
 } from "lucide-react";
 import { rpc } from "../../api/rpc";
+import { UNIT_OPTIONS } from "../../constants";
 
 // ---------------------------------------------------------------------------
 // Types — RPC response shapes from `imports.parse_document_for_import`.
@@ -112,8 +113,6 @@ function makeSteps(upTo: number, running: number): ImportStep[] {
 // ---------------------------------------------------------------------------
 // Main View
 // ---------------------------------------------------------------------------
-
-const UNIT_OPTIONS = ["hour", "day", "piece", "flat"] as const;
 
 export function DocumentImportView() {
   const [phase, setPhase] = useState<Phase>("upload");
@@ -762,6 +761,9 @@ function InvoiceCard({ item, onUpdate, importedContracts, importedProjects, exis
             const missing = (f: string, v: any) => ireq(f) && (v == null || v === "");
             const borderCls = (f: string, v: any) =>
               missing(f, v) ? "border-red-400/60" : "border-fuchsia-400/20";
+            const unitOptions = li.unit && !(UNIT_OPTIONS as readonly string[]).includes(li.unit)
+              ? [...UNIT_OPTIONS, li.unit]
+              : [...UNIT_OPTIONS];
             return (
             <div key={idx} className="grid grid-cols-[1fr_80px_60px_90px_70px_28px] gap-1.5 items-end">
               <div>
@@ -785,7 +787,7 @@ function InvoiceCard({ item, onUpdate, importedContracts, importedProjects, exis
                 <select value={li.unit ?? ""} onChange={(e) => updateItem(idx, "unit", e.target.value)}
                   className={`w-full px-2 py-1 rounded text-xs bg-bg-card text-primary border ${borderCls("unit", li.unit)} outline-none focus:border-fuchsia-400`}>
                   <option value="" disabled>Select unit</option>
-                  {UNIT_OPTIONS.map((u) => <option key={u} value={u}>{u}</option>)}
+                  {unitOptions.map((u) => <option key={u} value={u}>{u}</option>)}
                 </select>
               </div>
               <div>

--- a/ui/src/components/invoicing/InvoicingView.tsx
+++ b/ui/src/components/invoicing/InvoicingView.tsx
@@ -6,6 +6,7 @@ import {
 } from "lucide-react";
 import { rpc, readFileAsDataURL } from "../../api/rpc";
 import { str, num, bool, entity as subEntity, list as entityList, formatDate, invoiceStatus, deepStr, isReminder, reminderLevel } from "../../api/entity";
+import { UNIT_OPTIONS } from "../../constants";
 import { StatusBadge } from "../shared/StatusBadge";
 import { ViewModeToggle } from "../shared/ViewModeToggle";
 import { KanbanBoard, useStageStore, type BoardColumn } from "../shared/KanbanBoard";
@@ -217,8 +218,6 @@ interface LineItem {
   unit: string;
   unitPrice: string;
 }
-
-const UNIT_OPTIONS = ["hour", "day", "piece", "flat"] as const;
 
 function makeDefaultItem(project?: Entity | null): LineItem {
   const contract = project ? (project as Record<string, unknown>).contract as Record<string, unknown> | undefined : undefined;

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -1,0 +1,1 @@
+export const UNIT_OPTIONS = ["hour", "day", "piece", "flat"] as const;


### PR DESCRIPTION
## Summary

The document import view had a free-text `<input>` for the unit field on each parsed line item. The invoice parser tries to recognize units from the document text, but when it gets it wrong or the original invoice doesn't specify one clearly, there's no way to fix it without deleting and re-adding the item. The invoicing view already defines a fixed set of units (hour, day, piece, flat), so the import UI should match.

Changed the unit `<input>` to a `<select>` dropdown using the same UNIT_OPTIONS values the invoicing view uses (`InvoicingView.tsx` line 221). Items where the parser couldn't recognize a unit (null/undefined in the data) map to a "Select unit" placeholder option that's disabled so it can't be submitted empty. The data flow through `updateItem(idx, "unit", e.target.value)` is unchanged since `<select>` elements expose `e.target.value` the same way `<input>` does.

Built with tsc and vite, both pass cleanly. Styling classes preserved exactly from the existing input element.

Fixes #379

(I used AI assistance for drafting and build verification.)

## Checklist

- [x] I have read the [Contributing guide](../CONTRIBUTING.md).
- [ ] I have installed and tested the application for my platform (`just dev`).
- [ ] The test suite passes locally (`just test`).
- [ ] Pre-commit hooks are installed and pass (`just precommit`).
- [ ] I have added or updated tests where appropriate.
- [ ] I have updated the documentation / docstrings where appropriate.
- [ ] If my change touches the schema (`tuttle/model.py`), I generated and reviewed an Alembic migration (`just migrate "<msg>"`).
- [ ] If my change affects the graphical user interface, I have provided screenshots.
- [x] I understand and can explain all submitted changes; if AI assistance was significant, I have disclosed it in the summary above.
