### PR TITLE
Add introductory notes to empty views

### DIFF
--- a/ui/src/components/business/ClientsView.tsx
+++ b/ui/src/components/business/ClientsView.tsx
@@ -7,6 +7,7 @@ import { rpc } from "../../api/rpc";
 import { str, num, entity as subEntity, displayName, fullName } from "../../api/entity";
 import { Toolbar, ToolbarButtonPrimary, ToolbarButtonSecondary, ListDetailLayout, LIST_ROW_PADDING } from "../shared/ToolbarButtons";
 import { EditableClientContactRole } from "../shared/EditableClientContactRole";
+import { EmptyStateIntro } from "../shared/EmptyStateIntro";
 import type { Entity } from "../../api/types";
 
 type Mode = "view" | "edit" | "create" | "import";
@@ -156,10 +157,13 @@ export function ClientsView() {
         search={{ value: search, onChange: setSearch }}
       />
 
+      {clients.length === 0 && mode === "view" ? (
+        <EmptyStateIntro icon={Building2} description="A client is a company or person you do business with. Add clients to link them to contracts and invoices." />
+      ) : (
       <ListDetailLayout
         footer={<>{filtered.length} client{filtered.length !== 1 ? "s" : ""}</>}
         list={filtered.length === 0
-          ? <div className="p-4 text-sm text-center text-tertiary">{search ? "No matches." : "No clients."}</div>
+          ? <div className="p-4 text-sm text-center text-tertiary">No matches.</div>
           : filtered.map((c) => (
             <ClientRow key={c.id} client={c}
               isSelected={selected?.id === c.id && mode !== "create" && mode !== "import"}
@@ -188,6 +192,7 @@ export function ClientsView() {
           )
         }
       />
+      )}
     </div>
   );
 }

--- a/ui/src/components/business/ContractsView.tsx
+++ b/ui/src/components/business/ContractsView.tsx
@@ -9,6 +9,7 @@ import { str, num, bool, entity as subEntity, list as entityList, displayName, f
 import { Toolbar, ToolbarButtonPrimary, ToolbarButtonSecondary, ToolbarFilterGroup, ListDetailLayout, LIST_ROW_PADDING } from "../shared/ToolbarButtons";
 import { StatusBadge } from "../shared/StatusBadge";
 import { useNavigation } from "../shared/NavigationContext";
+import { EmptyStateIntro } from "../shared/EmptyStateIntro";
 import type { Entity } from "../../api/types";
 
 type Mode = "view" | "edit" | "create" | "import";
@@ -182,10 +183,13 @@ export function ContractsView() {
         search={{ value: search, onChange: setSearch }}
       />
 
+      {contracts.length === 0 && mode === "view" ? (
+        <EmptyStateIntro icon={FileText} description="A contract defines the business terms for working with a client — rate, billing cycle, and duration of the agreement." />
+      ) : (
       <ListDetailLayout
         footer={<>{filtered.length} contract{filtered.length !== 1 ? "s" : ""}</>}
         list={filtered.length === 0
-          ? <div className="p-4 text-sm text-center text-tertiary">{search || statusFilter !== "All" ? "No matches." : "No contracts."}</div>
+          ? <div className="p-4 text-sm text-center text-tertiary">No matches.</div>
           : filtered.map((c) => (
             <ContractRow key={c.id} contract={c}
               isSelected={selected?.id === c.id && mode !== "create" && mode !== "import"}
@@ -217,6 +221,7 @@ export function ContractsView() {
           )
         }
       />
+      )}
     </div>
   );
 }

--- a/ui/src/components/business/ProjectsView.tsx
+++ b/ui/src/components/business/ProjectsView.tsx
@@ -12,6 +12,7 @@ import { ViewModeToggle } from "../shared/ViewModeToggle";
 import { KanbanBoard, useStageStore, type BoardColumn } from "../shared/KanbanBoard";
 import { Toolbar, ToolbarButtonPrimary, ToolbarButtonSecondary, ToolbarFilterGroup, ListDetailLayout, LIST_ROW_PADDING } from "../shared/ToolbarButtons";
 import { useNavigation } from "../shared/NavigationContext";
+import { EmptyStateIntro } from "../shared/EmptyStateIntro";
 import type { Entity } from "../../api/types";
 
 interface BudgetEntry {
@@ -214,11 +215,13 @@ export function ProjectsView() {
         search={{ value: search, onChange: setSearch }}
       />
 
-      {viewMode === "list" ? (
+      {projects.length === 0 && mode === "view" ? (
+        <EmptyStateIntro icon={FolderKanban} description="A project is a unit of work you do under a contract. Track time against projects to generate invoices." />
+      ) : viewMode === "list" ? (
         <ListDetailLayout
           footer={<>{filtered.length} project{filtered.length !== 1 ? "s" : ""}</>}
           list={filtered.length === 0
-            ? <div className="p-4 text-sm text-center text-tertiary">{search ? "No matches." : "No projects."}</div>
+            ? <div className="p-4 text-sm text-center text-tertiary">No matches.</div>
             : filtered.map((p) => {
               const isSelected = selected?.id === p.id && mode === "view";
               const isHighlighted = !isSelected && navFilter.contractId != null && num(p, "contract_id") === navFilter.contractId;

--- a/ui/src/components/contacts/ContactsView.tsx
+++ b/ui/src/components/contacts/ContactsView.tsx
@@ -7,6 +7,7 @@ import { rpc } from "../../api/rpc";
 import { str, num, entity as subEntity, fullName, initials, displayName } from "../../api/entity";
 import { Toolbar, ToolbarButtonPrimary, ToolbarButtonSecondary, ListDetailLayout, LIST_ROW_PADDING } from "../shared/ToolbarButtons";
 import { EditableClientContactRole } from "../shared/EditableClientContactRole";
+import { EmptyStateIntro } from "../shared/EmptyStateIntro";
 import type { Entity } from "../../api/types";
 
 type Mode = "view" | "edit" | "create" | "import";
@@ -178,10 +179,13 @@ export function ContactsView() {
         search={{ value: search, onChange: setSearch }}
       />
 
+      {contacts.length === 0 && mode === "view" ? (
+        <EmptyStateIntro icon={Users} description="Contacts are people in your professional network — colleagues at client companies, or other collaborators." />
+      ) : (
       <ListDetailLayout
         footer={<>{filtered.length} contact{filtered.length !== 1 ? "s" : ""}</>}
         list={filtered.length === 0
-          ? <div className="p-4 text-sm text-center text-tertiary">{search ? "No matches." : "No contacts."}</div>
+          ? <div className="p-4 text-sm text-center text-tertiary">No matches.</div>
           : filtered.map((c) => (
             <ContactRow key={c.id} contact={c}
               isSelected={selected?.id === c.id && mode !== "create" && mode !== "import"}
@@ -217,6 +221,7 @@ export function ContactsView() {
           )
         }
       />
+      )}
     </div>
   );
 }

--- a/ui/src/components/dashboard/DashboardView.tsx
+++ b/ui/src/components/dashboard/DashboardView.tsx
@@ -6,6 +6,7 @@ import {
 import { rpc } from "../../api/rpc";
 import { str, num, int } from "../../api/entity";
 import { KPICard } from "../shared/KPICard";
+import { EmptyStateIntro } from "../shared/EmptyStateIntro";
 import type { Entity } from "../../api/types";
 import {
   Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend,
@@ -105,9 +106,7 @@ export function DashboardView() {
 
   if (loading) return <div className="flex items-center justify-center h-full text-secondary">Loading dashboard…</div>;
   if (!kpis) return (
-    <div className="flex flex-col items-center justify-center h-full gap-2 text-secondary">
-      <BarChart3 size={40} strokeWidth={1.2} /><span>No data. Install demo data to get started.</span>
-    </div>
+    <EmptyStateIntro icon={BarChart3} description="Your key business metrics — revenue, outstanding payments, and project progress — will appear here." />
   );
 
   return (

--- a/ui/src/components/import/DocumentImportView.tsx
+++ b/ui/src/components/import/DocumentImportView.tsx
@@ -443,8 +443,7 @@ function UploadPhase({ parsing, parseError, importSteps, onFileSelected }: {
       <div className="text-center space-y-2">
         <h2 className="text-xl font-semibold">Import a Document</h2>
         <p className="text-sm text-secondary">
-          Upload a document and AI will extract contracts, invoices, clients,
-          contacts, and projects from it.
+          Import contacts, clients, and contracts from documents using AI-powered extraction.
         </p>
       </div>
 

--- a/ui/src/components/invoicing/InvoicingView.tsx
+++ b/ui/src/components/invoicing/InvoicingView.tsx
@@ -11,6 +11,7 @@ import { ViewModeToggle } from "../shared/ViewModeToggle";
 import { KanbanBoard, useStageStore, type BoardColumn } from "../shared/KanbanBoard";
 import { Toolbar, ToolbarButtonPrimary, ToolbarFilterGroup, ListDetailLayout, LIST_ROW_PADDING } from "../shared/ToolbarButtons";
 import { useNavigation } from "../shared/NavigationContext";
+import { EmptyStateIntro } from "../shared/EmptyStateIntro";
 import type { Entity } from "../../api/types";
 
 type InvoiceChain = { root: Entity; reminders: Entity[] };
@@ -149,11 +150,13 @@ export function InvoicingView() {
         </div>
       )}
 
-      {viewMode === "list" ? (
+      {invoices.length === 0 ? (
+        <EmptyStateIntro icon={FileText} description="Invoices are how you bill clients for completed work. Create, track, and send them from here." />
+      ) : viewMode === "list" ? (
         <ListDetailLayout
           footer={<>{filtered.length} invoice{filtered.length !== 1 ? "s" : ""}</>}
           list={chains.length === 0
-            ? <div className="p-4 text-sm text-center text-tertiary">{search ? "No matches." : "No invoices."}</div>
+            ? <div className="p-4 text-sm text-center text-tertiary">No matches.</div>
             : chains.map((chain) => {
               const inv = chain.root;
               const isSelected = selected?.id === inv.id;

--- a/ui/src/components/salary/SalaryView.tsx
+++ b/ui/src/components/salary/SalaryView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { Wallet, BarChart3 } from "lucide-react";
 import { rpc } from "../../api/rpc";
+import { EmptyStateIntro } from "../shared/EmptyStateIntro";
 import type { Entity } from "../../api/types";
 import { num } from "../../api/entity";
 
@@ -54,11 +55,7 @@ export function SalaryView() {
 
   if (!salary) {
     return (
-      <div className="flex flex-col items-center justify-center h-full gap-3 text-secondary">
-        <Wallet size={40} strokeWidth={1.2} />
-        <span className="text-lg font-medium">Effective Salary</span>
-        <span className="text-sm text-muted">No invoice data yet. Start by adding contracts and tracking time.</span>
-      </div>
+      <EmptyStateIntro icon={Wallet} description="Your effective salary is what remains after taxes and business expenses — your actual take-home as a freelancer." />
     );
   }
 

--- a/ui/src/components/shared/EmptyStateIntro.tsx
+++ b/ui/src/components/shared/EmptyStateIntro.tsx
@@ -1,0 +1,13 @@
+import type { LucideIcon } from "lucide-react";
+
+export function EmptyStateIntro({ icon: Icon, description }: {
+  icon: LucideIcon;
+  description: string;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-3 text-secondary px-6 text-center">
+      <Icon size={40} strokeWidth={1.2} />
+      <div className="text-sm text-tertiary max-w-md">{description}</div>
+    </div>
+  );
+}

--- a/ui/src/components/tax/TaxReservesView.tsx
+++ b/ui/src/components/tax/TaxReservesView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { BarChart3, Receipt, Calculator, ChevronDown } from "lucide-react";
 import { rpc } from "../../api/rpc";
+import { EmptyStateIntro } from "../shared/EmptyStateIntro";
 import type { Entity } from "../../api/types";
 import { str, num, bool } from "../../api/entity";
 
@@ -65,6 +66,10 @@ export function TaxReservesView() {
   const hasAnyIncome = sp && (num(sp, "gross_revenue_ytd") > 0 || num(sp, "planned_revenue") > 0);
   const isCurrentYear = selectedYear === new Date().getFullYear();
   const periodLabel = isCurrentYear ? "YTD" : `${selectedYear}`;
+
+  if (!hasAnyIncome && months.length === 0) {
+    return <EmptyStateIntro icon={Calculator} description="Tax reserves help you set aside money for income tax and VAT throughout the year, so nothing comes as a surprise." />;
+  }
 
   return (
     <div className="p-6 space-y-6 max-w-3xl">

--- a/ui/src/components/timeline/TimelineView.tsx
+++ b/ui/src/components/timeline/TimelineView.tsx
@@ -5,6 +5,7 @@ import {
 } from "lucide-react";
 import { rpc } from "../../api/rpc";
 import { Toolbar, ToolbarFilterGroup } from "../shared/ToolbarButtons";
+import { EmptyStateIntro } from "../shared/EmptyStateIntro";
 import type { Entity } from "../../api/types";
 import { str, bool } from "../../api/entity";
 
@@ -131,11 +132,7 @@ export function TimelineView() {
     return (
       <div className="flex flex-col h-full">
         <Toolbar title="Timeline" />
-        <div className="flex flex-col items-center justify-center flex-1 gap-3 text-secondary">
-          <CalendarDays size={40} strokeWidth={1.2} />
-          <span className="text-lg font-medium">No Events Yet</span>
-          <span className="text-sm text-muted">Create invoices, contracts, or projects to see them here.</span>
-        </div>
+        <EmptyStateIntro icon={CalendarDays} description="Key events — new contracts, sent invoices, and project milestones — appear here in chronological order." />
       </div>
     );
   }

--- a/ui/src/components/timetracking/TimeTrackingView.tsx
+++ b/ui/src/components/timetracking/TimeTrackingView.tsx
@@ -399,12 +399,17 @@ function SourceChooser({
           Your calendar connection could not be restored. Please reconnect below.
         </div>
       )}
-      <h3 className="text-base font-semibold text-primary">Choose your calendar source</h3>
-      <p className="text-xs text-secondary max-w-sm text-center leading-relaxed">
-        Tag calendar events with project hashtags (e.g. <code className="font-semibold text-primary">#myproject</code>) to assign them to projects.
-      </p>
+      <Clock size={40} strokeWidth={1.2} className="text-secondary" />
+      <div className="max-w-md text-center space-y-2">
+        <p className="text-sm text-tertiary">
+          Time tracking records the hours you spend on projects, so you can generate accurate timesheets and invoices.
+        </p>
+        <p className="text-xs text-tertiary">
+          Tuttle reads your calendar events and matches them to projects using hashtags in the event title (e.g. <code className="font-semibold text-primary">#myproject</code>).
+        </p>
+      </div>
 
-      <div className={`flex gap-4 w-full max-w-xl ${isMac ? "" : "justify-center"}`}>
+      <div className="flex gap-4 w-full max-w-xl">
         {/* Option A: ICS file */}
         <div
           className={`flex-1 max-w-xs flex flex-col items-center gap-3 rounded-xl border-2 border-dashed p-8 transition-colors cursor-default ${dragOver ? "border-accent bg-accent/10" : "border-border-subtle hover:border-secondary"}`}
@@ -429,8 +434,8 @@ function SourceChooser({
           )}
         </div>
 
-        {/* Option B: System Calendar (macOS only) */}
-        {isMac && (
+        {/* Option B: System Calendar */}
+        {isMac ? (
           <div className="flex-1 max-w-xs flex flex-col items-center gap-3 rounded-xl border-2 border-border-subtle p-8 transition-colors">
             <div className="w-12 h-12 rounded-2xl bg-bg-card flex items-center justify-center">
               <MonitorSmartphone size={22} strokeWidth={1.5} className="text-primary" />
@@ -438,7 +443,7 @@ function SourceChooser({
             <div className="text-center">
               <h4 className="text-sm font-semibold mb-1 text-primary">System Calendar</h4>
               <p className="text-xs text-secondary leading-relaxed">
-                Connect directly to a macOS calendar (iCloud, Google, etc.).
+                Connect directly to your system calendar.
               </p>
             </div>
 
@@ -484,6 +489,18 @@ function SourceChooser({
                 {sysCalLoading ? "Loading…" : "Connect"}
               </button>
             )}
+          </div>
+        ) : (
+          <div className="flex-1 max-w-xs flex flex-col items-center gap-3 rounded-xl border-2 border-border-subtle border-dashed p-8 opacity-60">
+            <div className="w-12 h-12 rounded-2xl bg-bg-card flex items-center justify-center">
+              <MonitorSmartphone size={22} strokeWidth={1.5} className="text-tertiary" />
+            </div>
+            <div className="text-center">
+              <h4 className="text-sm font-semibold mb-1 text-tertiary">System Calendar</h4>
+              <p className="text-xs text-tertiary leading-relaxed">
+                Not yet available on this platform.
+              </p>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- New shared `EmptyStateIntro` component (icon + description) replaces bare "No X." messages across all views
- List-detail views (Contracts, Clients, Projects, Contacts, Invoicing) show a full-page intro instead of the split layout when no data exists
- Full-page views (Dashboard, Timeline, Tax, Salary) use the same component for their empty states
- Time Tracking SourceChooser now leads with a conceptual explanation and shows the System Calendar option as "not yet available" on non-macOS instead of hiding it

## Test plan

- [x] Open each view with an empty database and verify the intro note displays correctly
- [x] Verify list-detail views show the split layout again after adding the first item
- [x] Verify "No matches." still appears when filtering/searching with data present
- [ ] Check Time Tracking on non-macOS shows the disabled System Calendar card


Made with [Cursor](https://cursor.com)