### PR TITLE
Reorder My Business sidebar to match creation flow

### DIFF
--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -29,10 +29,10 @@ const SECTIONS: { label: string; items: SidebarItem[] }[] = [
   {
     label: "My Business",
     items: [
-      { id: "projects", label: "Projects", icon: FolderKanban },
-      { id: "contracts", label: "Contracts", icon: FileSignature },
-      { id: "clients", label: "Clients", icon: Building2 },
       { id: "contacts", label: "Contacts", icon: Users },
+      { id: "clients", label: "Clients", icon: Building2 },
+      { id: "contracts", label: "Contracts", icon: FileSignature },
+      { id: "projects", label: "Projects", icon: FolderKanban },
     ],
   },
   {


### PR DESCRIPTION
## Summary
Reorders the "My Business" sidebar section from Projects → Contracts → Clients → Contacts to Contacts → Clients → Contracts → Projects, matching the natural order these entities are typically created in (contact → client → contract → project), as agreed in the issue discussion.

**Before:** Projects → Contracts → Clients → Contacts
**After:** Contacts → Clients → Contracts → Projects

<img width="271" height="212" alt="image" src="https://github.com/user-attachments/assets/60284237-12ea-4406-9801-198d5ff63346" />


Fixes #389

Note: `just test` shows 1 pre-existing failure (`test_rendering.py::test_creates_only_final_file`) due to a Windows `cp1252` encoding issue — confirmed via `git stash` that this also fails on `main` without my change, so it's unrelated to this PR.

AI assistance: used Claude to help locate the relevant sidebar component and confirm the change was scoped correctly.

## Checklist
- [x] I have read the [Contributing guide](../CONTRIBUTING.md).
- [x] I have installed and tested the application for my platform (`just dev`).
- [x] The test suite passes locally (`just test`).
- [x] Pre-commit hooks are installed and pass (`just precommit`).
- [ ] I have added or updated tests where appropriate.
- [ ] I have updated the documentation / docstrings where appropriate.
- [ ] If my change touches the schema (`tuttle/model.py`), I generated and reviewed an Alembic migration (`just migrate "<msg>"`).
- [x] If my change affects the graphical user interface, I have provided screenshots.
- [x] I understand and can explain all submitted changes; if AI assistance was significant, I have disclosed it in the summary above.