### PR TITLE
Fix UnicodeEncodeError when rendering HTML on non-UTF-8 locales

### DIFF
--- a/tuttle/rendering.py
+++ b/tuttle/rendering.py
@@ -248,7 +248,7 @@ def render_invoice(
     invoice_dir = Path(out_dir) / Path(invoice.prefix)
     invoice_dir.mkdir(parents=True, exist_ok=True)
     invoice_path = invoice_dir / Path(f"{invoice.prefix}.html")
-    with open(invoice_path, "w") as invoice_file:
+    with open(invoice_path, "w", encoding="utf-8") as invoice_file:
         invoice_file.write(html)
 
     # Copy all CSS files and subdirectories from the template
@@ -369,7 +369,7 @@ def render_timesheet(
         timesheet_dir = Path(out_dir) / Path(prefix)
         timesheet_dir.mkdir(parents=True, exist_ok=True)
         timesheet_path = timesheet_dir / Path(f"{prefix}.html")
-        with open(timesheet_path, "w") as timesheet_file:
+        with open(timesheet_path, "w", encoding="utf-8") as timesheet_file:
             timesheet_file.write(html)
         # copy stylsheets
         if style:

--- a/tuttle_tests/test_rendering.py
+++ b/tuttle_tests/test_rendering.py
@@ -1,3 +1,4 @@
+import locale
 import tempfile
 import pytest
 from pathlib import Path
@@ -57,6 +58,39 @@ class TestRenderTimesheet:
             dir = Path(out_dir) / Path(prefix)
             assert not dir.exists()
 
+    def test_writes_non_ascii_content_regardless_of_locale_encoding(
+        self, fake, monkeypatch
+    ):
+        """Regression test for #402.
+
+        `render_timesheet` used to open the output file without an explicit
+        encoding, so the write picked up the platform's preferred locale
+        encoding (e.g. cp1252 on Windows) and raised a UnicodeEncodeError for
+        any non-ASCII characters. Force a non-UTF-8 preferred encoding here to
+        simulate that environment and confirm the write now always uses
+        UTF-8.
+        """
+        monkeypatch.setattr(locale, "getpreferredencoding", lambda do_setlocale=True: "cp1252")
+
+        user = demo.create_fake_user(fake)
+        timesheet = demo.create_fake_timesheet(fake)
+        timesheet.title = "Zeiterfassung – 日本語 – café ☕"
+
+        with tempfile.TemporaryDirectory() as out_dir:
+            rendering.render_timesheet(
+                user=user,
+                timesheet=timesheet,
+                out_dir=out_dir,
+                document_format="html",
+                style="anvil",
+                only_final=False,
+            )
+
+            html_path = Path(out_dir) / timesheet.prefix / f"{timesheet.prefix}.html"
+            assert html_path.is_file()
+            content = html_path.read_text(encoding="utf-8")
+            assert "日本語" in content
+
 
 class TestRenderInvoice:
     """Tests for render_invoice"""
@@ -99,6 +133,38 @@ class TestRenderInvoice:
 
             dir = Path(out_dir) / Path(prefix)
             assert not dir.exists()
+
+    def test_writes_non_ascii_content_regardless_of_locale_encoding(
+        self, fake, monkeypatch
+    ):
+        """Regression test for #402.
+
+        `render_invoice` used to open the output file without an explicit
+        encoding, so the write picked up the platform's preferred locale
+        encoding (e.g. cp1252 on Windows) and raised a UnicodeEncodeError for
+        any non-ASCII characters. Force a non-UTF-8 preferred encoding here to
+        simulate that environment and confirm the write now always uses
+        UTF-8.
+        """
+        monkeypatch.setattr(locale, "getpreferredencoding", lambda do_setlocale=True: "cp1252")
+
+        user = demo.create_fake_user(fake)
+        invoice = demo.create_fake_invoice(fake, render=False)
+        invoice.notes = "Vielen Dank – 日本語 – café ☕"
+
+        with tempfile.TemporaryDirectory() as out_dir:
+            rendering.render_invoice(
+                user=user,
+                invoice=invoice,
+                out_dir=out_dir,
+                document_format="html",
+                only_final=False,
+            )
+
+            html_path = Path(out_dir) / invoice.prefix / f"{invoice.prefix}.html"
+            assert html_path.is_file()
+            content = html_path.read_text(encoding="utf-8")
+            assert "日本語" in content
 
     def test_due_date_shown_when_enabled(self, fake):
         user = demo.create_fake_user(fake)

--- a/tuttle_tests/test_rendering.py
+++ b/tuttle_tests/test_rendering.py
@@ -70,7 +70,9 @@ class TestRenderTimesheet:
         simulate that environment and confirm the write now always uses
         UTF-8.
         """
-        monkeypatch.setattr(locale, "getpreferredencoding", lambda do_setlocale=True: "cp1252")
+        monkeypatch.setattr(
+            locale, "getpreferredencoding", lambda do_setlocale=True: "cp1252"
+        )
 
         user = demo.create_fake_user(fake)
         timesheet = demo.create_fake_timesheet(fake)
@@ -146,7 +148,9 @@ class TestRenderInvoice:
         simulate that environment and confirm the write now always uses
         UTF-8.
         """
-        monkeypatch.setattr(locale, "getpreferredencoding", lambda do_setlocale=True: "cp1252")
+        monkeypatch.setattr(
+            locale, "getpreferredencoding", lambda do_setlocale=True: "cp1252"
+        )
 
         user = demo.create_fake_user(fake)
         invoice = demo.create_fake_invoice(fake, render=False)


### PR DESCRIPTION
## Summary

Fixes #402.

`render_invoice()` and `render_timesheet()` in `tuttle/rendering.py` wrote the
rendered HTML with a plain `open(path, "w")` call. Without an explicit
`encoding`, Python falls back to `locale.getpreferredencoding()`, which on
Windows is typically `cp1252` (or another non-UTF-8 codepage, e.g. `cp1251`
on Russian-locale Windows). Any non-ASCII character in the rendered output
(client names, addresses, notes, symbols) then raised `UnicodeEncodeError`
during the write.

This wasn't caught in CI because it only reproduces on platforms whose
default locale encoding isn't UTF-8 (i.e. Windows), while CI runs on
Linux/macOS where UTF-8 is the default.

**Fix:** pass `encoding="utf-8"` explicitly at both write sites in
`tuttle/rendering.py`, matching how the HTML is read back elsewhere in the
codebase (e.g. `convert_html_to_pdf` loads the file via its `file://` URI,
and other modules that read text already specify `encoding="utf-8"`).

## Checklist

- [x] I have read the [Contributing guide](../CONTRIBUTING.md).
- [ ] I have installed and tested the application for my platform (`just dev`).
- [x] The test suite passes locally (`just test`).
- [ ] Pre-commit hooks are installed and pass (`just precommit`).
- [x] I have added or updated tests where appropriate.
- [ ] I have updated the documentation / docstrings where appropriate.
- [x] If my change touches the schema (`tuttle/model.py`), I generated and reviewed an Alembic migration (`just migrate "<msg>"`). — N/A, this change doesn't touch `tuttle/model.py`.
- [x] If my change affects the graphical user interface, I have provided screenshots. — N/A, this is a backend-only fix with no UI surface.
- [x] I understand and can explain all submitted changes; if AI assistance was significant, I have disclosed it in the summary above.

### Notes on the checklist

- **`just dev` / manual GUI test**: I was not able to run the Electron shell
  in my sandbox (no display server, and `just`/`npm install` for the UI
  weren't available in this environment), so I could not exercise the fix
  through the actual Electron GUI. Instead, I ran a manual, out-of-pytest
  reproduction that drives the exact same code path the UI/RPC layer calls
  (`tuttle.rendering.render_invoice` / `render_timesheet`) end-to-end — see
  "Manual test" below for exactly what was run and observed. I want to be
  upfront that this is not the same as clicking through the desktop app.
- **`just test`**: `just` itself wasn't available either, so I ran the
  underlying command directly: `uv run pytest` → equivalent to
  `.venv/Scripts/python.exe -m pytest tuttle_tests/` → **373 passed, 1
  skipped**.
- **`just precommit`**: `pre-commit` is installed in the project venv, but
  its console-script wrapper failed to run in my sandbox with `error: uv
  trampoline failed to canonicalize script path` (an environment issue with
  the uv-built entry point, unrelated to this change). As a substitute I ran
  `black --check` on the two files this PR touches and found one existing
  formatting issue in the new test code (an unwrapped `monkeypatch.setattr`
  call over the line-length limit in `tuttle_tests/test_rendering.py`). I
  fixed it with `black` and pushed the formatting-only commit; both
  `rendering.py` and `test_rendering.py` are now `black --check` clean.
  I did not have `flake8` installed to check further, so I can't claim the
  full pre-commit suite passes, only the black formatting check.

## Manual test

Since the Electron GUI couldn't be launched in this sandbox, I wrote a
standalone script that exercises the real application workflow instead of
going through pytest:

1. Build realistic domain objects using the app's own demo-data generator
   (`tuttle.demo.create_fake_user/create_fake_client/create_fake_contract/
   create_fake_project/create_fake_timesheet/create_fake_invoice` — the same
   generator the app uses to seed demo data), then set the client name to
   `"Клиент ООО «Тест» – Müller & 日本語 Client ☕"` (Cyrillic, German
   umlaut, CJK, emoji) and propagate it into the invoice notes and
   timesheet title, simulating a freelancer with a non-English client.
2. Force `locale.getpreferredencoding()` to return `"cp1252"`, simulating
   the reported Windows environment (my sandbox's actual OS default is
   `cp1251` — Russian-locale Windows — which is itself a live, real-world
   instance of the same non-UTF-8-default bug class, confirmed when even a
   `print()` of the client name to my own console raised
   `UnicodeEncodeError` before I switched the script's stdout to UTF-8).
3. Call `rendering.render_invoice(..., document_format="html")` and
   `rendering.render_timesheet(..., document_format="html")` exactly as the
   RPC layer does, writing to a real temp directory on disk.
4. Assert the HTML files exist and that reading them back as UTF-8 contains
   the non-ASCII client name.

**Result on the pre-fix code** (temporarily reverted `encoding="utf-8"` back
to plain `open(path, "w")` to confirm the bug reproduces):

```
[FAIL] Invoice HTML render raised: UnicodeEncodeError: 'charmap' codec can't encode character '\xfc' in position 538: character maps to <undefined>
```

**Result on the fixed code** (this PR):

```
Client name (non-ASCII): 'Клиент ООО «Тест» – Müller & 日本語 Client ☕'
[OK] Invoice HTML rendered: ...\2026-07-10-1-клиент-ооо-«тест»-–-müller-&-日本語-client-☕.html (3515 bytes)
[OK] Timesheet HTML rendered: ...\facilitate-strategic-2026-06-10-2026-07-10.html (4956 bytes)
All workflows completed without UnicodeEncodeError.
```

I also verified the generated HTML on disk directly: reading it back as
UTF-8 contains the Cyrillic, umlaut, and CJK client-name text intact.

I additionally tried rendering the same invoice to PDF
(`document_format="pdf"`) to go one step further into the real "export and
send to client" workflow; that step failed with an unrelated
`plutoprint`/`file://` URL error in my sandbox (looks like a missing/broken
dependency for headless PDF rendering in this environment, not a
`UnicodeEncodeError`), so I'm not claiming PDF export was verified — only
the HTML rendering path that #402 is actually about.

## Tests

Added a regression test to each of `TestRenderTimesheet` and
`TestRenderInvoice` in `tuttle_tests/test_rendering.py`. Each test:

- monkeypatches `locale.getpreferredencoding` to return `"cp1252"`,
  simulating the reported Windows environment regardless of the host the
  suite runs on,
- renders a timesheet/invoice whose title/notes contain non-ASCII
  characters, and
- asserts the HTML file is written successfully and its UTF-8 content is
  readable back.

Both new tests fail with `UnicodeEncodeError` against the pre-fix code and
pass after the fix. Full suite: `uv run pytest tuttle_tests/` — 373 passed,
1 skipped.

## AI assistance disclosure

This PR (code fix, tests, and this description) was drafted with
significant AI assistance. I reviewed the diff, understand the root cause
(missing explicit `encoding="utf-8"` at the two `open()` call sites) and the
fix, and ran the tests and manual reproduction above myself.
