### PR TITLE
Upgrade Electron 36 → 43 to fix Linux GTK crash

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tuttle-ui",
-  "version": "3.10.0",
+  "version": "3.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tuttle-ui",
-      "version": "3.10.0",
+      "version": "3.14.0",
       "dependencies": {
         "electron-updater": "^6.6.2",
         "lucide-react": "^0.511.0",
@@ -20,7 +20,7 @@
         "@types/react-dom": "^19.1.3",
         "@vitejs/plugin-react": "^4.4.1",
         "autoprefixer": "^10.4.21",
-        "electron": "^36.2.1",
+        "electron": "^43.1.0",
         "electron-builder": "^26.8.1",
         "playwright": "^1.61.1",
         "postcss": "^8.5.3",
@@ -354,6 +354,16 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz",
+      "integrity": "sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
@@ -458,25 +468,61 @@
       }
     },
     "node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
         "progress": "^2.0.3",
-        "semver": "^6.2.0",
+        "semver": "^7.6.3",
         "sumchecker": "^3.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=22.12.0"
       },
       "optionalDependencies": {
-        "global-agent": "^3.0.0"
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/get/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/get/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@electron/notarize": {
@@ -2310,13 +2356,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
-      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/plist": {
@@ -2368,17 +2414,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -2887,16 +2922,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -3735,22 +3760,22 @@
       }
     },
     "node_modules/electron": {
-      "version": "36.9.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-36.9.5.tgz",
-      "integrity": "sha512-1UCss2IqxqujSzg/2jkRjuiT3G+EEXgd6UKB5kUekwQW1LJ6d4QCr8YItfC3Rr9VIGRDJ29eOERmnRNO1Eh+NA==",
+      "version": "43.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.1.0.tgz",
+      "integrity": "sha512-DPfxpQLd4NL3BJ8DBxYAfmLUKKesF5Rx9dQx5FyczAP8bhOPScjHE48GArVeXu68LlAainuwkmQTQvdZwpIIAQ==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^22.7.7",
-        "extract-zip": "^2.0.1"
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
-        "node": ">= 12.20.55"
+        "node": ">= 22.12.0"
       }
     },
     "node_modules/electron-builder": {
@@ -4190,27 +4215,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/extsprintf": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
@@ -4244,16 +4248,6 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4342,21 +4336,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fs.realpath": {
@@ -5745,13 +5724,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/jet2jet"
       }
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7235,9 +7207,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -7529,17 +7501,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -101,7 +101,7 @@
     "@types/react-dom": "^19.1.3",
     "@vitejs/plugin-react": "^4.4.1",
     "autoprefixer": "^10.4.21",
-    "electron": "^36.2.1",
+    "electron": "^43.1.0",
     "electron-builder": "^26.8.1",
     "playwright": "^1.61.1",
     "postcss": "^8.5.3",


### PR DESCRIPTION
## Summary

- Upgrades Electron from `^36.2.1` to `^43.1.0` in `ui/package.json`
- Fixes the GTK 2/3 vs GTK 4 symbol conflict that crashes the AppImage on GNOME-based Linux distros (Asahi Linux / Fedora)
- Root cause: Electron 36 defaulted to GTK 4 on GNOME, but Chromium still loads GTK 2/3 symbols internally, causing a fatal `Gtk-ERROR` before any window renders. Fixed upstream in Electron 37+ ([electron/electron#46538](https://github.com/electron/electron/issues/46538))

Closes #410

## Test plan

- [ ] CI passes on all 4 platform targets (macOS arm64, Windows, Linux x64, Linux arm64)
- [ ] Smoke-test the Linux AppImage on a GNOME desktop (ideally Fedora / Asahi)
- [ ] Verify auto-updater still works on macOS and Windows
- [ ] Confirm `titleBarStyle: "hiddenInset"` renders correctly on macOS

## Checklist

- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] Vite build passes (`npm run build`)
- [x] No Tuttle code changes needed — only dependency bump

Made with [Cursor](https://cursor.com)