### PR TITLE
Fix UnicodeEncodeError when writing rendered HTML on Windows

### DIFF
--- a/tuttle/rendering.py
+++ b/tuttle/rendering.py
@@ -248,7 +248,7 @@ def render_invoice(
     invoice_dir = Path(out_dir) / Path(invoice.prefix)
     invoice_dir.mkdir(parents=True, exist_ok=True)
     invoice_path = invoice_dir / Path(f"{invoice.prefix}.html")
-    with open(invoice_path, "w") as invoice_file:
+    with open(invoice_path, "w", encoding="utf-8") as invoice_file:
         invoice_file.write(html)
 
     # Copy all CSS files and subdirectories from the template
@@ -369,7 +369,7 @@ def render_timesheet(
         timesheet_dir = Path(out_dir) / Path(prefix)
         timesheet_dir.mkdir(parents=True, exist_ok=True)
         timesheet_path = timesheet_dir / Path(f"{prefix}.html")
-        with open(timesheet_path, "w") as timesheet_file:
+        with open(timesheet_path, "w", encoding="utf-8") as timesheet_file:
             timesheet_file.write(html)
         # copy stylsheets
         if style:


### PR DESCRIPTION
## Summary
- `render_invoice` and `render_timesheet` in `tuttle/rendering.py` opened the output HTML file with `open(path, "w")`, which uses the system's default locale encoding (e.g. `cp1252` on Windows) instead of UTF-8.
- Non-ASCII characters in the rendered template then raise `UnicodeEncodeError` on Windows.
- Both call sites now explicitly pass `encoding="utf-8"`.

Fixes #402

## Test plan
- [x] `uv run pytest tuttle_tests/test_rendering.py -q` — 6 passed
- [x] `uv run pytest -q` (full suite) — 371 passed, 1 skipped

Made with [Cursor](https://cursor.com)