### PR TITLE
fix(ui): list recurring expenses in effective salary breakdown (#413)

### DIFF
--- a/ui/src/components/salary/SalaryView.tsx
+++ b/ui/src/components/salary/SalaryView.tsx
@@ -148,6 +148,9 @@ function MonthlyBreakdown({ salary }: { salary: SalaryData }) {
     { label: "Gross Revenue / month", amount: gross, color: "var(--color-status-info)" },
     { label: "VAT (to remit)", amount: vatReserve, color: "var(--color-status-warning)" },
     { label: "Est. Income Tax + Soli", amount: incomeTaxReserve, color: "var(--color-status-warning)" },
+    // Recurring expenses are already subtracted from available salary; list them so the
+    // breakdown matches Expenses view data (tuttle-dev/tuttle#413).
+    { label: "Recurring expenses", amount: monthlyExpenses, color: "var(--color-status-warning)" },
     { label: "= Available Salary", amount: optimistic, color: optimistic >= 0 ? "var(--color-status-success)" : "var(--color-status-danger)", bold: true },
   ];
 


### PR DESCRIPTION
## Summary
- Surface monthly recurring expenses in the Effective Salary Monthly Breakdown.
- Backend already subtracted expenses; UI now matches Expenses view data.

## Test plan
- [x] `npx tsc --noEmit` in `ui/`
- [x] `pytest tuttle_tests/test_tax.py` (60 passed)
- [ ] Manual: add a recurring expense, open Effective Salary, confirm line appears and available salary decreases accordingly.

Fixes #413