### PR TITLE
feat(tax): support Steuernummer (schemeID FC) for sellers without a VAT ID

### DIFF
--- a/tuttle/einvoice.py
+++ b/tuttle/einvoice.py
@@ -162,10 +162,8 @@ def build_zugferd_document(
             TaxRegistration(id=("VA", user.VAT_number))
         )
     elif user.tax_number:
-        # A freelancer still awaiting the USt-IdNr owes a §14 UStG identifier just
-        # the same. EN16931 only bars the VAT identifier ("VA") from outside-scope
-        # invoices (BR-O-02); the tax number under scheme "FC" (Steuernummer) is
-        # valid on any invoice, so fall back to it when no VAT number is set.
+        # No USt-IdNr yet: §14 UStG still needs an identifier, and FC (Steuernummer)
+        # is legal on any invoice — unlike VA (BR-O-02).
         doc.trade.agreement.seller.tax_registrations.add(
             TaxRegistration(id=("FC", user.tax_number))
         )

--- a/tuttle/einvoice.py
+++ b/tuttle/einvoice.py
@@ -161,6 +161,14 @@ def build_zugferd_document(
         doc.trade.agreement.seller.tax_registrations.add(
             TaxRegistration(id=("VA", user.VAT_number))
         )
+    elif user.tax_number:
+        # A freelancer still awaiting the USt-IdNr owes a §14 UStG identifier just
+        # the same. EN16931 only bars the VAT identifier ("VA") from outside-scope
+        # invoices (BR-O-02); the tax number under scheme "FC" (Steuernummer) is
+        # valid on any invoice, so fall back to it when no VAT number is set.
+        doc.trade.agreement.seller.tax_registrations.add(
+            TaxRegistration(id=("FC", user.tax_number))
+        )
     if user.email and not is_minimum:
         doc.trade.agreement.seller.electronic_address.uri_ID = ("EM", user.email)
 

--- a/tuttle/rendering.py
+++ b/tuttle/rendering.py
@@ -247,15 +247,17 @@ def render_invoice(
         tpl = labels.get("reminder_n", "{n}. Payment Reminder")
         reminder_title = tpl.format(n=n)
 
-    # EN16931 BR-O-02 keeps the VAT number off an outside-scope e-invoice, so the
-    # printed document must not contradict the embedded XML: show the tax number
-    # (Steuernummer) instead, and nothing at all when the user has not set one.
-    if invoice.is_outside_scope:
+    # Mirror the embedded XML (see einvoice.py): EN16931 BR-O-02 keeps the VAT
+    # number off an outside-scope invoice, and a seller still awaiting the
+    # USt-IdNr falls back to the tax number (Steuernummer, scheme FC). Show the
+    # VAT number only when it may appear and is set; otherwise the tax number,
+    # and nothing at all when neither is set.
+    if not invoice.is_outside_scope and user.VAT_number:
+        seller_tax_id_label = labels.get("vat_number", "VAT No.")
+        seller_tax_id = user.VAT_number
+    else:
         seller_tax_id_label = labels.get("tax_number", "Tax No.")
         seller_tax_id = user.tax_number or ""
-    else:
-        seller_tax_id_label = labels.get("vat_number", "VAT No.")
-        seller_tax_id = user.VAT_number or ""
 
     invoice_template = template_env.get_template("invoice.html")
     html = invoice_template.render(

--- a/tuttle/rendering.py
+++ b/tuttle/rendering.py
@@ -247,11 +247,8 @@ def render_invoice(
         tpl = labels.get("reminder_n", "{n}. Payment Reminder")
         reminder_title = tpl.format(n=n)
 
-    # Mirror the embedded XML (see einvoice.py): EN16931 BR-O-02 keeps the VAT
-    # number off an outside-scope invoice, and a seller still awaiting the
-    # USt-IdNr falls back to the tax number (Steuernummer, scheme FC). Show the
-    # VAT number only when it may appear and is set; otherwise the tax number,
-    # and nothing at all when neither is set.
+    # Mirror the XML (einvoice.py): VAT number when it may appear and is set,
+    # else the tax number, else nothing.
     if not invoice.is_outside_scope and user.VAT_number:
         seller_tax_id_label = labels.get("vat_number", "VAT No.")
         seller_tax_id = user.VAT_number

--- a/tuttle_tests/test_einvoice.py
+++ b/tuttle_tests/test_einvoice.py
@@ -175,6 +175,56 @@ class TestBuildZugferdDocument:
         assert "DE123456789" in xml_str
         assert "DE89370400440532013000" in xml_str
 
+    def test_seller_vat_number_emitted_as_scheme_va(self):
+        user = _make_user()
+        invoice = _make_invoice()
+        xml_str = serialize_zugferd_xml(invoice, user, profile="EN16931").decode(
+            "utf-8"
+        )
+        assert '<ram:ID schemeID="VA">DE123456789</ram:ID>' in xml_str
+
+    @staticmethod
+    def _seller_party(xml_str: str) -> str:
+        return re.search(
+            r"<ram:SellerTradeParty>.*?</ram:SellerTradeParty>", xml_str, re.S
+        ).group(0)
+
+    def test_seller_tax_number_falls_back_to_scheme_fc_without_vat_number(self):
+        """A freelancer awaiting the USt-IdNr still owes a §14 UStG identifier;
+        on a standard (in-scope) invoice CII carries it under scheme FC."""
+        user = _make_user()
+        user.VAT_number = None
+        user.tax_number = "21/815/08150"
+        invoice = _make_invoice()
+        xml_str = serialize_zugferd_xml(
+            invoice, user, profile="EN16931", validate=True
+        ).decode("utf-8")
+        seller = self._seller_party(xml_str)
+        assert '<ram:ID schemeID="FC">21/815/08150</ram:ID>' in seller
+        assert 'schemeID="VA"' not in seller
+
+    def test_seller_vat_number_wins_over_tax_number_when_both_set(self):
+        user = _make_user()
+        user.tax_number = "21/815/08150"
+        invoice = _make_invoice()
+        xml_str = serialize_zugferd_xml(invoice, user, profile="EN16931").decode(
+            "utf-8"
+        )
+        assert '<ram:ID schemeID="VA">DE123456789</ram:ID>' in xml_str
+        assert "21/815/08150" not in xml_str
+
+    def test_no_seller_tax_identifier_without_vat_or_tax_number(self):
+        user = _make_user()
+        user.VAT_number = None
+        user.tax_number = None
+        invoice = _make_invoice()
+        xml_str = serialize_zugferd_xml(invoice, user, profile="EN16931").decode(
+            "utf-8"
+        )
+        seller = self._seller_party(xml_str)
+        assert 'schemeID="VA"' not in seller
+        assert 'schemeID="FC"' not in seller
+
     def test_xml_contains_buyer_info(self):
         user = _make_user()
         invoice = _make_invoice()

--- a/tuttle_tests/test_einvoice.py
+++ b/tuttle_tests/test_einvoice.py
@@ -175,14 +175,6 @@ class TestBuildZugferdDocument:
         assert "DE123456789" in xml_str
         assert "DE89370400440532013000" in xml_str
 
-    def test_seller_vat_number_emitted_as_scheme_va(self):
-        user = _make_user()
-        invoice = _make_invoice()
-        xml_str = serialize_zugferd_xml(invoice, user, profile="EN16931").decode(
-            "utf-8"
-        )
-        assert '<ram:ID schemeID="VA">DE123456789</ram:ID>' in xml_str
-
     @staticmethod
     def _seller_party(xml_str: str) -> str:
         return re.search(

--- a/tuttle_tests/test_rendering.py
+++ b/tuttle_tests/test_rendering.py
@@ -270,6 +270,26 @@ class TestSellerTaxIdentifierInFooter:
         )
         assert "DE123456789" not in html
 
+    @pytest.mark.parametrize("template_name", ALL_INVOICE_TEMPLATES)
+    def test_standard_invoice_falls_back_to_tax_number_without_vat_number(
+        self, fake, template_name
+    ):
+        """A seller awaiting the USt-IdNr: the printed invoice shows the tax
+        number, mirroring the FC identifier embedded in the XML."""
+        user = self._user(fake, "21/815/08150")
+        user.VAT_number = None
+        html = _render(user, demo.create_fake_invoice(fake), template_name)
+        assert "21/815/08150" in html
+
+    @pytest.mark.parametrize("template_name", ALL_INVOICE_TEMPLATES)
+    def test_standard_invoice_without_any_identifier_shows_neither(
+        self, fake, template_name
+    ):
+        user = self._user(fake, None)
+        user.VAT_number = None
+        html = _render(user, demo.create_fake_invoice(fake), template_name)
+        assert "DE123456789" not in html
+
     @pytest.mark.parametrize(
         "language,label",
         [("en", "VAT No."), ("de", "USt-IdNr."), ("es", "N.º IVA")],

--- a/tuttle_tests/test_rendering.py
+++ b/tuttle_tests/test_rendering.py
@@ -281,15 +281,6 @@ class TestSellerTaxIdentifierInFooter:
         html = _render(user, demo.create_fake_invoice(fake), template_name)
         assert "21/815/08150" in html
 
-    @pytest.mark.parametrize("template_name", ALL_INVOICE_TEMPLATES)
-    def test_standard_invoice_without_any_identifier_shows_neither(
-        self, fake, template_name
-    ):
-        user = self._user(fake, None)
-        user.VAT_number = None
-        html = _render(user, demo.create_fake_invoice(fake), template_name)
-        assert "DE123456789" not in html
-
     @pytest.mark.parametrize(
         "language,label",
         [("en", "VAT No."), ("de", "USt-IdNr."), ("es", "N.º IVA")],

--- a/ui/src/components/layout/OnboardingWizard.tsx
+++ b/ui/src/components/layout/OnboardingWizard.tsx
@@ -28,6 +28,7 @@ export interface WizardProfileData {
   city: string;
   country: string;
   vat_number: string;
+  tax_number: string;
   operating_country: string;
   bank_name: string;
   bank_IBAN: string;
@@ -66,7 +67,7 @@ type Props = {
 const EMPTY_PROFILE: WizardProfileData = {
   name: "", subtitle: "", email: "", phone: "", website: "",
   street: "", street_num: "", postal_code: "", city: "", country: "Germany",
-  vat_number: "", operating_country: "Germany",
+  vat_number: "", tax_number: "", operating_country: "Germany",
   bank_name: "", bank_IBAN: "", bank_BIC: "",
 };
 
@@ -155,7 +156,9 @@ export function OnboardingWizard({ open, onClose, onSubmit, onDemo, loading, ove
         profile.street.trim() &&
         profile.city.trim() &&
         profile.country.trim() &&
-        profile.vat_number.trim() &&
+        // A VAT number (USt-IdNr.) or a tax number (Steuernummer) is enough:
+        // freelancers awaiting their USt-IdNr start out with only the latter.
+        (profile.vat_number.trim() || profile.tax_number.trim()) &&
         profile.operating_country.trim()
       );
     }
@@ -314,22 +317,33 @@ export function OnboardingWizard({ open, onClose, onSubmit, onDemo, loading, ove
           </div>
         </fieldset>
 
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label className={labelCls}>VAT number <span className="text-accent">*</span></label>
-            <input className={inputCls} value={profile.vat_number} onChange={pset("vat_number")} placeholder="DE123456789" />
+        <div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelCls}>VAT number</label>
+              <input className={inputCls} value={profile.vat_number} onChange={pset("vat_number")} placeholder="DE123456789" />
+            </div>
+            <div>
+              <label className={labelCls}>Tax number</label>
+              <input className={inputCls} value={profile.tax_number} onChange={pset("tax_number")} placeholder="21/815/08150" />
+            </div>
           </div>
-          <div>
-            <label className={labelCls}>Operating country <span className="text-accent">*</span></label>
-            <select className={inputCls} value={profile.operating_country} onChange={pset("operating_country")}>
-              {supportedCountries.length > 0 ? (
-                supportedCountries.map((c) => <option key={c} value={c}>{c}</option>)
-              ) : (
-                <option value={profile.operating_country}>{profile.operating_country}</option>
-              )}
-            </select>
-            <p className="mt-1 text-xs text-muted">Determines tax rules and default currency.</p>
-          </div>
+          <p className="mt-1 text-xs text-muted">
+            Enter your VAT number (USt-IdNr.) or, until you receive one, your tax number
+            (Steuernummer) <span className="text-accent">*</span>. At least one appears on your invoices.
+          </p>
+        </div>
+
+        <div>
+          <label className={labelCls}>Operating country <span className="text-accent">*</span></label>
+          <select className={inputCls} value={profile.operating_country} onChange={pset("operating_country")}>
+            {supportedCountries.length > 0 ? (
+              supportedCountries.map((c) => <option key={c} value={c}>{c}</option>)
+            ) : (
+              <option value={profile.operating_country}>{profile.operating_country}</option>
+            )}
+          </select>
+          <p className="mt-1 text-xs text-muted">Determines tax rules and default currency.</p>
         </div>
 
         <fieldset className="border border-border-subtle rounded-lg px-4 pb-3 pt-2">

--- a/ui/src/components/layout/OnboardingWizard.tsx
+++ b/ui/src/components/layout/OnboardingWizard.tsx
@@ -156,8 +156,7 @@ export function OnboardingWizard({ open, onClose, onSubmit, onDemo, loading, ove
         profile.street.trim() &&
         profile.city.trim() &&
         profile.country.trim() &&
-        // A VAT number (USt-IdNr.) or a tax number (Steuernummer) is enough:
-        // freelancers awaiting their USt-IdNr start out with only the latter.
+        // Freelancers awaiting the USt-IdNr have only a Steuernummer.
         (profile.vat_number.trim() || profile.tax_number.trim()) &&
         profile.operating_country.trim()
       );
@@ -317,33 +316,30 @@ export function OnboardingWizard({ open, onClose, onSubmit, onDemo, loading, ove
           </div>
         </fieldset>
 
-        <div>
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className={labelCls}>VAT number</label>
-              <input className={inputCls} value={profile.vat_number} onChange={pset("vat_number")} placeholder="DE123456789" />
-            </div>
-            <div>
-              <label className={labelCls}>Tax number</label>
-              <input className={inputCls} value={profile.tax_number} onChange={pset("tax_number")} placeholder="21/815/08150" />
-            </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className={labelCls}>VAT number</label>
+            <input className={inputCls} value={profile.vat_number} onChange={pset("vat_number")} placeholder="DE123456789" />
           </div>
-          <p className="mt-1 text-xs text-muted">
+          <div>
+            <label className={labelCls}>Tax number</label>
+            <input className={inputCls} value={profile.tax_number} onChange={pset("tax_number")} placeholder="21/815/08150" />
+          </div>
+          <p className="col-span-2 text-xs text-muted">
             Enter your VAT number (USt-IdNr.) or, until you receive one, your tax number
             (Steuernummer) <span className="text-accent">*</span>. At least one appears on your invoices.
           </p>
-        </div>
-
-        <div>
-          <label className={labelCls}>Operating country <span className="text-accent">*</span></label>
-          <select className={inputCls} value={profile.operating_country} onChange={pset("operating_country")}>
-            {supportedCountries.length > 0 ? (
-              supportedCountries.map((c) => <option key={c} value={c}>{c}</option>)
-            ) : (
-              <option value={profile.operating_country}>{profile.operating_country}</option>
-            )}
-          </select>
-          <p className="mt-1 text-xs text-muted">Determines tax rules and default currency.</p>
+          <div>
+            <label className={labelCls}>Operating country <span className="text-accent">*</span></label>
+            <select className={inputCls} value={profile.operating_country} onChange={pset("operating_country")}>
+              {supportedCountries.length > 0 ? (
+                supportedCountries.map((c) => <option key={c} value={c}>{c}</option>)
+              ) : (
+                <option value={profile.operating_country}>{profile.operating_country}</option>
+              )}
+            </select>
+            <p className="mt-1 text-xs text-muted">Determines tax rules and default currency.</p>
+          </div>
         </div>
 
         <fieldset className="border border-border-subtle rounded-lg px-4 pb-3 pt-2">

--- a/ui/src/components/settings/SettingsView.tsx
+++ b/ui/src/components/settings/SettingsView.tsx
@@ -532,13 +532,14 @@ export function SettingsView() {
             <legend className="text-xs font-medium text-secondary px-1">Tax &amp; Legal</legend>
             <div className="grid grid-cols-2 gap-3 mt-1">
               <div>
-                <label className={labelCls}>VAT number <span className="text-accent">*</span></label>
+                <label className={labelCls}>VAT number</label>
                 <input className={inputCls} value={profile.VAT_number} onChange={pset("VAT_number")} placeholder="DE123456789" />
+                <p className="text-xs text-secondary mt-1">USt-IdNr. Preferred identifier on invoices when available.</p>
               </div>
               <div>
                 <label className={labelCls}>Tax number</label>
                 <input className={inputCls} value={profile.tax_number} onChange={pset("tax_number")} placeholder="21/815/08150" />
-                <p className="text-xs text-secondary mt-1">Steuernummer. Used on invoices outside the scope of VAT, where the VAT number may not appear.</p>
+                <p className="text-xs text-secondary mt-1">Steuernummer. Shown when you have no VAT number yet, and on invoices outside the scope of VAT where the VAT number may not appear.</p>
               </div>
               <div>
                 <label className={labelCls}>Operating country <span className="text-accent">*</span></label>


### PR DESCRIPTION
## Summary

Addresses tuttle-dev/tuttle#391 — *"Seller tax registration field only supports VAT-ID (schemeID VA), no option for Steuernummer (schemeID FC)"*.

German freelancers often start out with only a **Steuernummer** (tax number, e.g. `21/815/08150`) before their **USt-IdNr** (VAT ID) is issued. EN16931 distinguishes the two via schemeID (`VA` for the VAT registration, `FC` for the fiscal/tax number).

The `tax_number` field, the settings input, the `FC` XML scheme, and the PDF footer already existed — but only for invoices **outside the scope of VAT** (added for #390). An **in-scope** seller who had only a Steuernummer therefore got **no** seller tax identifier in the Factur-X XML and an **empty "VAT No."** on the PDF. This PR closes that gap.

### Changes
- **`einvoice.py`** — fall back to the tax number under scheme `FC` when the seller has no VAT number. EN16931 only bars the VAT identifier (`VA`) from outside-scope invoices (BR-O-02); `FC` is valid on any invoice, and §14 UStG still requires an identifier. The VAT number still wins when both are set.
- **`rendering.py`** — mirror the XML in the printed footer: show the VAT number when present, otherwise the tax number, and nothing when neither is set (keeps the PDF consistent with the embedded XML).
- **`OnboardingWizard.tsx`** — add a *Tax number* field and require a VAT **or** tax number, so a freelancer awaiting the USt-IdNr is no longer blocked during first-run setup. (The backend `users.create` already accepted `tax_number`.)
- **`SettingsView.tsx`** — clarify the VAT/tax number labels and hints to match the new "either identifier" behaviour.
- **Tests** — `test_einvoice.py`: standard invoice emits `FC` when no VAT number, `VA` wins when both are set, and neither when both are empty (all validated against the EN16931 schematron). `test_rendering.py`: printed footer falls back to the tax number for a standard invoice with no VAT number, across all templates.

### Verification
- `just test` equivalent: `uv run pytest` → **497 passed, 1 skipped**; `uv run ruff check` / `ruff format --check` clean.
- UI: `npx tsc --noEmit` (app scope) clean, `vite build` succeeds.

AI assistance disclosure: this change was implemented with AI assistance (Claude Code); all changes have been reviewed and are explained above.

## Checklist

- [x] I have read the [Contributing guide](../CONTRIBUTING.md).
- [x] I have installed and tested the application for my platform (`just dev`) — app launches, dashboard and settings load against a dev DB.
- [x] The test suite passes locally (`just test`).
- [ ] Pre-commit hooks are installed (`just precommit`) and pass — yaml / end-of-file / trailing-whitespace pass; the pinned `black` hook crashes in pre-commit's isolated env on Python 3.14 (`asyncio.get_event_loop()` removed), independent of this branch. `uv run ruff format --check` / `ruff check` are clean.
- [x] I have added or updated tests where appropriate.
- [x] I have updated the documentation / docstrings where appropriate.
- [x] If my change touches the schema (`tuttle/model.py`), I generated and reviewed an Alembic migration (`just migrate "<msg>"`). — n/a, no schema change (`tax_number` already exists).
- [ ] If my change affects the graphical user interface, I have provided screenshots.
- [x] I understand and can explain all submitted changes; if AI assistance was significant, I have disclosed it in the summary above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKUKXrX4VFW7rgnCqcy6Nq)_
