### PR TITLE
fix(ui): display recurring expenses in effective salary breakdown

### DIFF
--- a/ui/src/components/salary/SalaryView.tsx
+++ b/ui/src/components/salary/SalaryView.tsx
@@ -148,6 +148,7 @@ function MonthlyBreakdown({ salary }: { salary: SalaryData }) {
     { label: "Gross Revenue / month", amount: gross, color: "var(--color-status-info)" },
     { label: "VAT (to remit)", amount: vatReserve, color: "var(--color-status-warning)" },
     { label: "Est. Income Tax + Soli", amount: incomeTaxReserve, color: "var(--color-status-warning)" },
+    { label: "Recurring Expenses", amount: monthlyExpenses, color: "var(--color-status-warning)" },
     { label: "= Available Salary", amount: optimistic, color: optimistic >= 0 ? "var(--color-status-success)" : "var(--color-status-danger)", bold: true },
   ];
 


### PR DESCRIPTION
## Summary

Adds a Recurring Expenses row to the Effective Salary breakdown. This fixes a visual bug where expenses were subtracted in the background but not displayed.
Placed the Recurring Expenses row after the tax lines since VAT and Income Tax rows.

**Before**: Gross Revenue → VAT → Est. Income Tax + Soli → Available Salary
**After**: Gross Revenue → VAT → Est. Income Tax + Soli → Recurring Expenses → Available Salary

<img width="769" height="690" alt="image" src="https://github.com/user-attachments/assets/3b870a05-54a0-4077-a184-83b11253f5e4" />

AI assistance: used Claude to get an overview of component structure of the Effective Salary page.

Happy to adjust the row placement or anything else if you'd prefer a different approach.

Fixes #413 

## Checklist

- [x] I have read the [Contributing guide](../CONTRIBUTING.md).
- [x] I have installed and tested the application for my platform (`just dev`).
- [x] The test suite passes locally (`just test`).
- [x] Pre-commit hooks are installed and pass (`just precommit`).
- [ ] I have added or updated tests where appropriate.
- [ ] I have updated the documentation / docstrings where appropriate.
- [ ] If my change touches the schema (`tuttle/model.py`), I generated and reviewed an Alembic migration (`just migrate "<msg>"`).
- [x] If my change affects the graphical user interface, I have provided screenshots.
- [x] I understand and can explain all submitted changes; if AI assistance was significant, I have disclosed it in the summary above.
