### PR TITLE
fix: make the append-only migration guard formatting-immune

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,6 +18,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        # Full history: test_versions_are_append_only_in_git walks per-file git
+        # log and passes vacuously under the default shallow (depth 1) clone.
+        fetch-depth: 0
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/tuttle_tests/test_migrations.py
+++ b/tuttle_tests/test_migrations.py
@@ -197,9 +197,35 @@ def test_versions_are_append_only_in_git() -> None:
     or any subsequent commits must only modify docstrings/comments —
     never op.* calls.
 
+    The comparison is done on the parsed op.* calls rather than on the raw
+    diff, so a reformat (line joining, import sorting) does not count as an
+    edit — only a change to what the call actually does.
+
     Skipped outside a git checkout (e.g. wheel installs).
     """
+    import ast
     import subprocess
+
+    def op_calls(source: str) -> list[str]:
+        """Every op.* call in upgrade(), normalized so formatting is invisible.
+
+        Only upgrade() is compared: that is the code every already-migrated
+        database has executed. downgrade() bodies were legitimately replaced
+        by `raise NotImplementedError` after the fact — see
+        test_downgrades_are_not_supported.
+        """
+        upgrade = next(
+            (node for node in ast.parse(source).body if isinstance(node, ast.FunctionDef) and node.name == "upgrade"),
+            ast.Module(body=[], type_ignores=[]),  # no upgrade() -> no op.* calls
+        )
+        return [
+            ast.unparse(node)
+            for node in ast.walk(upgrade)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "op"
+        ]
 
     versions = Path(__file__).resolve().parent.parent / "tuttle" / "migrations" / "versions"
     try:
@@ -212,8 +238,17 @@ def test_versions_are_append_only_in_git() -> None:
     except (FileNotFoundError, subprocess.CalledProcessError):
         pytest.skip("Not a git checkout; cannot enforce append-only.")
 
+    # Known pre-existing violation, grandfathered so the guard can go live for
+    # everything else: commit 9cec3e0 changed this revision's NULL backfill from
+    # "" to "Unknown" after it had shipped. Databases that migrated before that
+    # commit hold "", ones after hold "Unknown". Tracked in #429 — do not extend
+    # this set, add a new revision instead.
+    grandfathered = {"c3d70beffa72_make_contact_first_name_and_last_name_.py"}
+
     offenders: list[str] = []
     for script in versions.glob("*.py"):
+        if script.name in grandfathered:
+            continue
         result = subprocess.run(
             ["git", "log", "--pretty=format:%H", "--", script.name],
             cwd=versions,
@@ -223,18 +258,15 @@ def test_versions_are_append_only_in_git() -> None:
         commits = [c for c in result.stdout.strip().splitlines() if c]
         if len(commits) <= 1:
             continue
-        # Diff only post-creation commits (exclude oldest = creation commit)
-        oldest = commits[-1]
-        diff = subprocess.run(
-            ["git", "diff", f"{oldest}..HEAD", "--", script.name],
+        # Oldest commit created the file; compare its op.* calls with today's
+        original = subprocess.run(
+            ["git", "show", f"{commits[-1]}:./{script.name}"],
             cwd=versions,
             capture_output=True,
             text=True,
         )
-        for line in diff.stdout.splitlines():
-            if line.startswith("+    op."):
-                offenders.append(script.name)
-                break
+        if op_calls(original.stdout) != op_calls(script.read_text()):
+            offenders.append(script.name)
 
     assert not offenders, (
         f"These migration scripts have post-commit edits to op.* calls: {offenders}. "


### PR DESCRIPTION
## Summary

Targets #427. Ruff reformatted committed revisions in `tuttle/migrations/versions`, joining multi-line `op.execute(...)` calls onto one line. **The formatting stays** — the guard was the problem.

`test_versions_are_append_only_in_git` compared raw diff text, so a cosmetic reflow read as an edit to a shipped schema delta. It fails on #427 locally: 503 passed, 1 failed.

Now it compares the parsed `op.*` calls in `upgrade()`. Reflows and import sorting are invisible; a change to what a call actually does still fails. Scoped to `upgrade()` because that is the code already-migrated databases executed, and because `downgrade()` bodies were legitimately replaced with `raise NotImplementedError` after the fact.

## The guard has never actually run in CI

`actions/checkout` defaults to `fetch-depth: 1`, and the check skips any file whose per-file `git log` returns one commit. Under a shallow clone that is every file, so the assert has always passed vacuously — which is why #427 shows 504 passed while a full checkout shows a failure. Set `fetch-depth: 0`.

Turning it on surfaces a **real pre-existing violation on main**, unrelated to ruff: `c3d70beffa72` had its NULL backfill changed from empty string to `"Unknown"` by `9cec3e0` after shipping. Grandfathered here with a comment so the guard can go live for every other revision; tracked in #429.

## Changes

- `tuttle_tests/test_migrations.py`: AST-based comparison, one grandfathered file
- `.github/workflows/python-package.yml`: `fetch-depth: 0`

No migration files touched.

## Test plan

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean (137 files)
- [x] `pytest` — 504 passed, 1 skipped
- [x] Negative control: guard still fails on a planted table rename in `8ec5efc5316d`
- [x] Positive control: guard no longer fails on ruff's reflow of `8de1ce679065`
- [ ] CI passes

Unrelated, not fixed here: `pre-commit run --all-files` fails `end-of-file-fixer` on `AGENTS.md` (missing trailing newline, pre-existing on main), and the `ruff` hook id logs as a legacy alias for `ruff-check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
