### PR TITLE
Fix timetracking tag filter hiding All after project selection

### DIFF
--- a/ui/src/components/timetracking/TimeTrackingView.tsx
+++ b/ui/src/components/timetracking/TimeTrackingView.tsx
@@ -76,6 +76,7 @@ export function TimeTrackingView() {
   const [month, setMonth] = useState(new Date().getMonth() + 1);
   const [selectedDay, setSelectedDay] = useState<string | null>(null);
   const [filterTag, setFilterTag] = useState<string | null>(null);
+  const [availableTags, setAvailableTags] = useState<string[]>([]);
   const [importing, setImporting] = useState(false);
   const [dragOver, setDragOver] = useState(false);
   const [calendarSource, setCalendarSource] = useState<CalendarSource>(null);
@@ -112,6 +113,12 @@ export function TimeTrackingView() {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => { if (!restoringSource) loadData(); }, [loadData]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Keep full tag list for filter pills — calData.projects is filtered when a tag is active.
+  useEffect(() => {
+    if (!calData || filterTag) return;
+    setAvailableTags(calData.projects.map((p) => p.tag));
+  }, [calData, filterTag]);
 
   // ── Navigation ──────────────────────────────────────────────────────────
 
@@ -198,6 +205,8 @@ export function TimeTrackingView() {
     await rpc("timetracking.clear");
     setCalendarSource(null);
     setSelectedDay(null);
+    setFilterTag(null);
+    setAvailableTags([]);
     setSystemCals(null);
     loadData();
   }
@@ -205,9 +214,10 @@ export function TimeTrackingView() {
   // ── Derived data ────────────────────────────────────────────────────────
 
   const allTags = useMemo(() => {
-    if (!calData) return [];
+    if (filterTag && availableTags.length > 0) return availableTags;
+    if (!calData) return availableTags;
     return calData.projects.map((p) => p.tag);
-  }, [calData]);
+  }, [calData, filterTag, availableTags]);
 
   const dayEvents = useMemo(() => {
     if (!selectedDay || !calData) return [];
@@ -287,7 +297,7 @@ export function TimeTrackingView() {
                   <button onClick={goToday} className="text-xs font-medium text-secondary hover:text-primary hover:underline">Today</button>
                   <div className="flex-1" />
                   {/* Tag filter */}
-                  {allTags.length > 1 && (
+                  {(availableTags.length > 1 || filterTag) && (
                     <div className="flex items-center gap-1">
                       <button
                         onClick={() => setFilterTag(null)}

--- a/ui/src/components/timetracking/TimeTrackingView.tsx
+++ b/ui/src/components/timetracking/TimeTrackingView.tsx
@@ -92,7 +92,15 @@ export function TimeTrackingView() {
   const loadData = useCallback(async () => {
     setLoading(true);
     const calRes = await rpc<CalendarData>("timetracking.get_calendar_data", { year, month, project_tag: filterTag });
-    if (calRes.ok && calRes.data) setCalData(calRes.data);
+    if (calRes.ok && calRes.data) {
+      setCalData(calRes.data);
+      if (!filterTag) {
+        const tags = calRes.data.projects.map((p) => p.tag);
+        setAvailableTags((prev) =>
+          prev.length === tags.length && prev.every((t, i) => t === tags[i]) ? prev : tags,
+        );
+      }
+    }
     setLoading(false);
   }, [year, month, filterTag]);
 
@@ -113,12 +121,6 @@ export function TimeTrackingView() {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => { if (!restoringSource) loadData(); }, [loadData]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Keep full tag list for filter pills — calData.projects is filtered when a tag is active.
-  useEffect(() => {
-    if (!calData || filterTag) return;
-    setAvailableTags(calData.projects.map((p) => p.tag));
-  }, [calData, filterTag]);
 
   // ── Navigation ──────────────────────────────────────────────────────────
 
@@ -214,10 +216,9 @@ export function TimeTrackingView() {
   // ── Derived data ────────────────────────────────────────────────────────
 
   const allTags = useMemo(() => {
-    if (filterTag && availableTags.length > 0) return availableTags;
-    if (!calData) return availableTags;
-    return calData.projects.map((p) => p.tag);
-  }, [calData, filterTag, availableTags]);
+    if (availableTags.length > 0) return availableTags;
+    return calData?.projects.map((p) => p.tag) ?? [];
+  }, [calData, availableTags]);
 
   const dayEvents = useMemo(() => {
     if (!selectedDay || !calData) return [];


### PR DESCRIPTION
## Summary

Fixes #430

When a project tag was selected in Time Tracking, the filter pills in the upper-right corner disappeared entirely — including the **All** button — making it impossible to return to the unfiltered view.

**Root cause:** `allTags` was derived from `calData.projects`, which the backend filters to the selected tag only. After selecting a tag, `allTags.length` dropped to 1, and the UI condition `allTags.length > 1` hid the whole filter bar.

**Fix:** Persist the unfiltered tag list in `availableTags` (updated whenever data loads without an active filter). The filter bar now stays visible while a tag is selected, and **All** clears the filter as expected.

## Test plan

- [x] `uv run pytest --tb=short -q` — 504 passed
- [x] Open Time Tracking with calendar data spanning 2+ project tags
- [x] Click a `#tag` pill — calendar filters to that project
- [x] Verify **All** and all tag pills remain visible in the upper-right corner
- [x] Click **All** — calendar returns to showing all projects
- [x] Click the same tag again — toggles back to **All** (existing behavior)


Made with [Cursor](https://cursor.com)