### PR TITLE
fix: make contact name fields optional, reconcile #429 backfill

### DIFF
--- a/tuttle/migrations/versions/bac018e35ce6_revert_contact_name_fields_to_optional_.py
+++ b/tuttle/migrations/versions/bac018e35ce6_revert_contact_name_fields_to_optional_.py
@@ -1,0 +1,97 @@
+"""revert contact name fields to optional with empty default
+
+Revision ID: bac018e35ce6
+Revises: 4447db01f757
+Create Date: 2026-07-26 11:55:54.559439
+
+======================================================================
+FROZEN HISTORICAL SNAPSHOT — NOT THE SCHEMA SOURCE OF TRUTH.
+
+The source of truth is tuttle/model.py. This file captures the schema
+DELTA from the previous revision to this point in history. It is
+APPEND-ONLY: once committed, never edit it. To change the schema, edit
+tuttle/model.py and run `just migrate "<msg>"` to ADD a new revision.
+
+Reading this file to learn the current schema is a MISTAKE — it is a
+point-in-time snapshot. Read tuttle/model.py instead.
+======================================================================
+
+MANDATORY REVIEW CHECKLIST before committing this file:
+
+1. RENAMES — autogenerate emits drop_column + add_column for renames,
+   which DESTROYS DATA. If you intended a rename, replace the pair with
+   op.alter_column(<table>, <old>, new_column_name=<new>).
+
+2. NO MODEL IMPORTS — never `from tuttle.model import ...` here.
+   Model classes drift over time; this script must be pinned to the
+   schema at this point in history. For data transformations, declare
+   a local sa.table(...) snapshot with only the columns this revision
+   touches.
+
+3. BATCH MODE — render_as_batch=True rebuilds tables for SQLite. After
+   a batch op on a table with foreign keys, verify integrity inside the
+   migration: op.execute("PRAGMA foreign_key_check").
+
+See tuttle/migrations/README.md.
+----------------------------------------------------------------------
+"""
+
+# pyright: reportAttributeAccessIssue=false
+# sqlmodel.sql.sqltypes is a submodule resolved at runtime; basedpyright
+# does not statically expose `sql` as an attribute of `sqlmodel`.
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+import sqlmodel.sql.sqltypes  # noqa: F401 — ensures runtime resolution of AutoString
+from alembic import op
+
+revision: str = "bac018e35ce6"
+down_revision: Union[str, Sequence[str], None] = "4447db01f757"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    contact = sa.table(
+        "contact",
+        sa.column("first_name", sa.VARCHAR()),
+        sa.column("last_name", sa.VARCHAR()),
+    )
+    # Reconcile both database populations from #429:
+    # - pre-9cec3e0 databases have "" (original backfill)  → keep as-is
+    # - post-9cec3e0 databases have "Unknown" (bad backfill) → revert to ""
+    op.execute(contact.update().where(contact.c.first_name == "Unknown").values(first_name=""))
+    op.execute(contact.update().where(contact.c.last_name == "Unknown").values(last_name=""))
+
+    with op.batch_alter_table("contact", schema=None) as batch_op:
+        batch_op.alter_column(
+            "first_name",
+            existing_type=sa.VARCHAR(),
+            nullable=True,
+            server_default="",
+        )
+        batch_op.alter_column(
+            "last_name",
+            existing_type=sa.VARCHAR(),
+            nullable=True,
+            server_default="",
+        )
+
+    op.execute("PRAGMA foreign_key_check")
+
+
+def downgrade() -> None:
+    """Downgrades are not supported.
+
+    Tuttle is a single-user desktop app. Rolling back schema is destructive
+    (data in dropped columns is lost) and offers nothing over restoring a
+    timestamped backup from ensure_schema()'s pre-upgrade snapshot.
+
+    If you need to iterate on a migration during development:
+    1. Delete this revision file (versions/bac018e35ce6_*.py)
+    2. Run `just reset` to wipe ~/.tuttle
+    3. Edit model.py, run `just migrate` again
+    """
+    raise NotImplementedError("Downgrades are not supported. Restore from a .bak-<ts> snapshot instead.")

--- a/tuttle/model.py
+++ b/tuttle/model.py
@@ -234,8 +234,8 @@ class Contact(RpcMixin, SQLModel, table=True):
     __rpc_relationships__ = ("address",)
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    first_name: str = Field(description="First / given name")
-    last_name: str = Field(description="Last / family name")
+    first_name: str = Field(default="", description="First / given name")
+    last_name: str = Field(default="", description="Last / family name")
     company: Optional[str] = Field(default=None, description="Company or organisation name")
     email: Optional[str] = Field(default=None, description="Email address")
     address_id: Optional[int] = Field(default=None, foreign_key="address.id")
@@ -251,10 +251,10 @@ class Contact(RpcMixin, SQLModel, table=True):
     )
 
     # VALIDATORS
-    @validator("first_name", "last_name")
-    def name_not_empty(cls, v):
-        if not v or not str(v).strip():
-            raise ValueError("Name is required")
+    @validator("first_name", "last_name", pre=True)
+    def strip_name(cls, v):
+        if v is None:
+            return ""
         return str(v).strip()
 
     @validator("email")

--- a/tuttle_tests/test_migrations.py
+++ b/tuttle_tests/test_migrations.py
@@ -238,11 +238,9 @@ def test_versions_are_append_only_in_git() -> None:
     except (FileNotFoundError, subprocess.CalledProcessError):
         pytest.skip("Not a git checkout; cannot enforce append-only.")
 
-    # Known pre-existing violation, grandfathered so the guard can go live for
-    # everything else: commit 9cec3e0 changed this revision's NULL backfill from
-    # "" to "Unknown" after it had shipped. Databases that migrated before that
-    # commit hold "", ones after hold "Unknown". Tracked in #429 — do not extend
-    # this set, add a new revision instead.
+    # c3d70beffa72 was edited after shipping (commit 9cec3e0 changed its
+    # backfill from "" to "Unknown"). Reconciled by bac018e35ce6, but the
+    # git history still shows the edit. See #429.
     grandfathered = {"c3d70beffa72_make_contact_first_name_and_last_name_.py"}
 
     offenders: list[str] = []

--- a/tuttle_tests/test_rpc_dispatch.py
+++ b/tuttle_tests/test_rpc_dispatch.py
@@ -282,7 +282,7 @@ class TestFieldRequirements:
     @pytest.mark.parametrize(
         "domain,required_fields",
         [
-            ("contacts", {"first_name", "last_name"}),
+            ("contacts", set()),
             ("clients", {"name"}),
             ("projects", {"title", "description", "tag", "start_date"}),
             ("contracts", {"title", "start_date", "currency"}),
@@ -324,13 +324,14 @@ class TestCrudSaveBehavior:
         assert saved["last_name"] == "Tuttle"
         assert saved.get("address") is None or saved.get("address") == {}
 
-    def test_contact_save_rejects_missing_name(self, rpc_env):
+    def test_contact_save_accepts_partial_name(self, rpc_env):
         result = dispatch(
             "contacts.save",
             {"contact": {"first_name": "Solo", "last_name": ""}},
         )
-        assert result["ok"] is False
-        assert result["error"]
+        assert_ok(result)
+        assert result["data"]["first_name"] == "Solo"
+        assert result["data"]["last_name"] == ""
 
     def test_project_save_without_end_date(self, rpc_env):
         contracts = assert_ok(dispatch("contracts.get_all", {}))["data"]

--- a/ui/src/components/contacts/ContactsView.tsx
+++ b/ui/src/components/contacts/ContactsView.tsx
@@ -773,8 +773,8 @@ function DocumentImportPanel({ parsing, parseError, parsedContacts, onFileSelect
 
 function contactIsValid(c: ParsedContact): { valid: boolean; missing: string[] } {
   const missing: string[] = [];
-  if (!c.first_name.trim()) missing.push("First Name");
-  if (!c.last_name.trim()) missing.push("Last Name");
+  const hasName = c.first_name.trim() || c.last_name.trim() || c.company.trim();
+  if (!hasName) missing.push("Name or Company");
   const addr = c.address;
   const hasAddress = !!(addr.street || addr.number || addr.city || addr.postal_code || addr.country);
   if (!hasAddress) missing.push("Address (at least one field)");
@@ -796,7 +796,7 @@ function ParsedContactCard({ contact, onAccept, onDiscard, onUpdate }: {
   }
 
   const { valid, missing } = contactIsValid(contact);
-  const name = [contact.first_name, contact.last_name].filter(Boolean).join(" ") || contact.company || "Unknown";
+  const name = [contact.first_name, contact.last_name].filter(Boolean).join(" ") || contact.company || "(unnamed)";
 
   return (
     <div className="rounded-xl border-2 border-fuchsia-400/40 bg-fuchsia-500/5 p-4 space-y-3">
@@ -831,8 +831,8 @@ function ParsedContactCard({ contact, onAccept, onDiscard, onUpdate }: {
       )}
 
       <div className="grid grid-cols-2 gap-2">
-        <AiField label="First Name" value={contact.first_name} onChange={(v) => updateField("first_name", v)} required missing={!contact.first_name.trim()} />
-        <AiField label="Last Name" value={contact.last_name} onChange={(v) => updateField("last_name", v)} required missing={!contact.last_name.trim()} />
+        <AiField label="First Name" value={contact.first_name} onChange={(v) => updateField("first_name", v)} />
+        <AiField label="Last Name" value={contact.last_name} onChange={(v) => updateField("last_name", v)} />
         <AiField label="Company" value={contact.company} onChange={(v) => updateField("company", v)} />
         <AiField label="Email" value={contact.email} onChange={(v) => updateField("email", v)} />
       </div>


### PR DESCRIPTION
## Summary

Fixes #429 — migration `c3d70beffa72` was edited after shipping, causing divergent database states where some users have `""` and others `"Unknown"` as backfill for contact name fields.

- **Model**: revert `Contact.first_name`/`last_name` to optional with `default=""`. Replace the `name_not_empty` validator (which rejected empty strings) with `strip_name` (normalises whitespace, accepts empty).
- **Migration** `bac018e35ce6`: reconciles both populations — `"Unknown"` → `""`, makes columns nullable. Idempotent for databases already holding `""`.
- **UI**: contact import validation now requires name-or-company instead of both first and last name. Name fields in the form derive their required status from the model schema via `useFieldRequirements`.
- **Tests**: updated field requirement expectations and replaced `test_contact_save_rejects_missing_name` with `test_contact_save_accepts_partial_name`.

## Test plan

- [x] Full test suite passes (504 passed, 1 skipped)
- [ ] Verify contact creation works with only company name (no first/last)
- [ ] Verify existing contacts with "Unknown" name are cleaned up after migration
- [ ] Verify e-invoice generation still works for contacts without personal names


Made with [Cursor](https://cursor.com)