### PR TITLE
fix: improve fixed-price invoice import quality

### DIFF
--- a/tuttle/llm.py
+++ b/tuttle/llm.py
@@ -138,8 +138,9 @@ def _flat_schema(model_cls: type, *, include: Optional[List[str]] = None) -> typ
 
     Uses model_fields (which already excludes relationships) and keeps only
     scalar columns. All fields made Optional for partial extraction.
-    Field descriptions are preserved so llama_index structured output
-    can communicate field semantics to the LLM via the JSON Schema.
+    Field descriptions are preserved so the JSON Schema communicates domain
+    semantics to the LLM — extraction quality depends on these descriptions,
+    not on post-processing or keyword matching.
     """
     fields: Dict[str, Any] = {}
     for name, field_info in model_cls.model_fields.items():
@@ -565,7 +566,13 @@ def _describe_entity_fields(model_cls: type, skip: set = {"ref"}) -> str:  # noq
 
 
 def _build_summary_prompt() -> str:
-    """Generate the Pass-1 summary prompt from the extraction model definitions."""
+    """Generate the Pass-1 summary prompt from the extraction model definitions.
+
+    Pass 1 asks the LLM for a free-text summary of document facts.
+    It relies on the LLM's semantic understanding of the document — no
+    canonical field values are prescribed here (that happens in Pass 2
+    via the structured schema).
+    """
     sections = []
     for label, model_cls in DocumentExtractionResult.model_fields.items():
         field_info = DocumentExtractionResult.model_fields[label]
@@ -579,9 +586,9 @@ def _build_summary_prompt() -> str:
         "You are analysing a business document (contract, invoice, or other) for a freelancer.\n"
         "Read the document carefully and list ALL facts relevant to the following categories.\n"
         "Be thorough — include every detail you can find, even if approximate.\n"
-        "If the document is an invoice, extract all line items with their quantities and amounts.\n\n"
-        + "\n\n".join(sections)
-        + "\n\nFormat all dates as YYYY-MM-DD. "
+        "If the document is an invoice, extract all line items with their quantities and amounts.\n"
+        "Note whether the invoice uses time-based billing (hourly/daily rates) "
+        "or fixed-price / lump-sum pricing.\n\n" + "\n\n".join(sections) + "\n\nFormat all dates as YYYY-MM-DD. "
         "Write one fact per line. Do not omit any details.\n\n"
     )
 
@@ -592,7 +599,10 @@ _DOC_EXTRACT_PROMPT = (
     "Convert the following entity summary into structured JSON.\n"
     "Use ref strings (contact_1, client_1, contract_1, project_1) to cross-link entities.\n"
     "Populate EVERY field you can; only use null for truly unknown values.\n"
-    "Dates must be YYYY-MM-DD.\n\n"
+    "Dates must be YYYY-MM-DD.\n"
+    "For invoice line items: use unit='hour' or 'day' for time-based billing. "
+    "For fixed-price / lump-sum items use unit='fixed_price', quantity=1, "
+    "and unit_price=total amount.\n\n"
 )
 
 
@@ -800,6 +810,26 @@ def _map_document_extraction(
     return mapped
 
 
+_CANONICAL_UNITS = {"hour", "day", "fixed_price"}
+
+
+def _normalize_unit(raw: str | None) -> str | None:
+    """Fix trivial formatting variations in LLM-extracted unit values.
+
+    The LLM performs semantic extraction — it understands whether an
+    invoice uses time-based or fixed-price billing from context, guided
+    by the JSON Schema field descriptions.  This function only cleans up
+    minor formatting differences (whitespace, trailing plural 's') that
+    can occur despite correct semantic understanding.
+    """
+    if raw is None:
+        return None
+    cleaned = raw.strip().lower().replace(" ", "_").rstrip("s")
+    if cleaned in _CANONICAL_UNITS:
+        return cleaned
+    return raw
+
+
 def _map_invoices(invoices: list) -> List[Dict[str, Any]]:
     """Map extracted invoice objects to dicts for the frontend."""
     from .model import normalize_vat_rate
@@ -815,6 +845,7 @@ def _map_invoices(invoices: list) -> List[Dict[str, Any]]:
             for k in list(item):
                 if k.endswith("_date"):
                     item[k] = _serialise_date(item[k])
+            item["unit"] = _normalize_unit(item.get("unit"))
             vat = item.get("VAT_rate")
             if vat is not None:
                 try:

--- a/tuttle/model.py
+++ b/tuttle/model.py
@@ -1167,11 +1167,21 @@ class InvoiceItem(RpcMixin, VatCategoryMixin, SQLModel, table=True):
     start_date: Optional[datetime.date] = Field(default=None, description="Start date of the invoice item.")
     end_date: Optional[datetime.date] = Field(default=None, description="End date of the invoice item.")
     #
-    quantity: float
-    unit: str
-    unit_price: Decimal
-    description: str
-    VAT_rate: Decimal
+    quantity: float = Field(
+        description="Number of units billed. For fixed-price / lump-sum items, use 1.",
+    )
+    unit: str = Field(
+        description="Billing unit: 'hour', 'day', or 'fixed_price'. Use 'fixed_price' for lump-sum / flat-rate items.",
+    )
+    unit_price: Decimal = Field(
+        description="Price per unit. For fixed-price items this equals the total amount.",
+    )
+    description: str = Field(
+        description="Description of the service or deliverable.",
+    )
+    VAT_rate: Decimal = Field(
+        description="VAT rate as a decimal fraction, e.g. 0.19 for 19%%.",
+    )
     VAT_category: TaxCategory = Field(
         description="Tax category, snapshotted from the contract at invoice "
         "creation so that later contract edits cannot alter an issued invoice.",

--- a/tuttle_tests/test_document_import.py
+++ b/tuttle_tests/test_document_import.py
@@ -634,3 +634,64 @@ class TestLlmInvoiceSchema:
         from tuttle.llm import _DOC_SUMMARY_PROMPT
 
         assert "INVOICES" in _DOC_SUMMARY_PROMPT
+
+    def test_summary_prompt_mentions_fixed_price(self):
+        """The summary prompt must guide the LLM on fixed-price invoices."""
+        from tuttle.llm import _DOC_SUMMARY_PROMPT
+
+        assert "fixed_price" in _DOC_SUMMARY_PROMPT or "fixed-price" in _DOC_SUMMARY_PROMPT
+
+    def test_extract_prompt_mentions_fixed_price(self):
+        """The extraction prompt must guide the LLM on fixed-price line items."""
+        from tuttle.llm import _DOC_EXTRACT_PROMPT
+
+        assert "fixed_price" in _DOC_EXTRACT_PROMPT
+
+    def test_invoice_item_schema_has_unit_description(self):
+        """The LLM schema for invoice items must describe the unit field."""
+        from tuttle.llm import _RefInvoiceItem
+
+        unit_info = _RefInvoiceItem.model_fields["unit"]
+        assert unit_info.description is not None
+        assert "fixed_price" in unit_info.description
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("hour", "hour"),
+            ("hours", "hour"),
+            ("day", "day"),
+            ("days", "day"),
+            ("fixed_price", "fixed_price"),
+            ("fixed price", "fixed_price"),
+            ("Fixed_Price", "fixed_price"),
+            (None, None),
+            ("widget", "widget"),
+        ],
+    )
+    def test_normalize_unit(self, raw, expected):
+        from tuttle.llm import _normalize_unit
+
+        assert _normalize_unit(raw) == expected
+
+    def test_map_invoices_normalizes_unit(self):
+        """_map_invoices must normalise trivial unit variations."""
+        from tuttle.llm import _map_invoices, _RefInvoice, _RefInvoiceItem
+
+        inv = _RefInvoice(
+            ref="inv_fp",
+            number="FP-001",
+            date=datetime.date(2024, 1, 1),
+            items=[
+                _RefInvoiceItem(
+                    quantity=1.0,
+                    unit="fixed price",
+                    unit_price=5000.0,
+                    description="Project delivery",
+                    VAT_rate=0.19,
+                )
+            ],
+        )
+
+        result = _map_invoices([inv])
+        assert result[0]["items"][0]["unit"] == "fixed_price"

--- a/ui/src/components/import/DocumentImportView.tsx
+++ b/ui/src/components/import/DocumentImportView.tsx
@@ -779,8 +779,13 @@ function InvoiceCard({ item, onUpdate, importedContracts, importedProjects, exis
                 <label className="block text-[10px] text-tertiary mb-0.5">
                   Unit{ireq("unit") && <span className="text-red-400 ml-0.5">*</span>}
                 </label>
-                <input value={li.unit} onChange={(e) => updateItem(idx, "unit", e.target.value)}
-                  className={`w-full px-2 py-1 rounded text-xs bg-bg-card text-primary border ${borderCls("unit", li.unit)} outline-none focus:border-fuchsia-400`} />
+                <select value={li.unit || ""} onChange={(e) => updateItem(idx, "unit", e.target.value)}
+                  className={`w-full px-1.5 py-1 rounded text-xs bg-bg-card text-primary border ${borderCls("unit", li.unit)} outline-none focus:border-fuchsia-400`}>
+                  <option value="">--</option>
+                  <option value="hour">hour</option>
+                  <option value="day">day</option>
+                  <option value="fixed_price">fixed price</option>
+                </select>
               </div>
               <div>
                 <label className="block text-[10px] text-tertiary mb-0.5">


### PR DESCRIPTION
## Summary

Fixes two related issues with the document import workflow for fixed-price invoices:

- **#383**: The LLM-based document import forced per-unit extraction on lump-sum invoices because the JSON Schema and prompts had no awareness of the `fixed_price` convention
- **#379**: The import UI rendered the unit field as a free-text input, preventing users from correcting misrecognised units

### Approach

LLM-based extraction relies on **semantic text understanding**, not keyword matching. The fix steers the LLM via schema descriptions and prompt guidance so it correctly identifies the pricing model from document context:

- **Model** (`tuttle/model.py`): Add `Field(description=...)` to `InvoiceItem` fields (`quantity`, `unit`, `unit_price`, `description`, `VAT_rate`) so the JSON Schema communicates valid values and their semantics to the LLM
- **Pass-1 prompt** (`tuttle/llm.py`): Ask the LLM to note the pricing model (time-based vs fixed-price) — no canonical values prescribed at this free-text stage
- **Pass-2 prompt** (`tuttle/llm.py`): Specify canonical unit values (`hour`, `day`, `fixed_price`) for the structured extraction step
- **Minimal normalization** (`tuttle/llm.py`): `_normalize_unit()` only fixes trivial formatting (whitespace, trailing plural 's') — semantic understanding is the primary mechanism
- **UI** (`DocumentImportView.tsx`): Replace unit free-text `<input>` with a `<select>` dropdown (hour / day / fixed price)

No database migration required — `Field(description=...)` is Pydantic metadata only.

## Test plan

- [x] `test_summary_prompt_mentions_fixed_price` and `test_extract_prompt_mentions_fixed_price` guard prompt content
- [x] `test_invoice_item_schema_has_unit_description` ensures schema descriptions flow through
- [x] Parametrized `test_normalize_unit` covers trivial formatting variations
- [x] `test_map_invoices_normalizes_unit` verifies end-to-end normalization
- [x] Full test suite passes (524 passed)

Closes #383
Closes #379