### PR TITLE
fix: align Contact name field types with migration nullable=True

### DIFF
--- a/tuttle/model.py
+++ b/tuttle/model.py
@@ -234,8 +234,8 @@ class Contact(RpcMixin, SQLModel, table=True):
     __rpc_relationships__ = ("address",)
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    first_name: str = Field(default="", description="First / given name")
-    last_name: str = Field(default="", description="Last / family name")
+    first_name: Optional[str] = Field(default="", description="First / given name")
+    last_name: Optional[str] = Field(default="", description="Last / family name")
     company: Optional[str] = Field(default=None, description="Company or organisation name")
     email: Optional[str] = Field(default=None, description="Email address")
     address_id: Optional[int] = Field(default=None, foreign_key="address.id")


### PR DESCRIPTION
## Summary

- PR #433 made migration `bac018e35ce6` set `contact.first_name`/`last_name` to `nullable=True`, but left the model annotation as `str` (NOT NULL in SQLModel). This causes `alembic check` to report schema drift and would generate a spurious migration on `just migrate`.
- Change the type annotation from `str` to `Optional[str]` so the model matches the database.
- No new migration needed — the model now agrees with the existing migration chain.

## Test plan

- [x] Full test suite passes (517 passed, 1 skipped)
- [x] `alembic check` reports no drift after the fix
- [x] Validator still coerces `None` → `""`, so runtime behavior is unchanged

Made with [Cursor](https://cursor.com)