### PR TITLE
Add circular list row icons to Contracts and Projects

### DIFF
--- a/ui/src/components/business/ContractsView.tsx
+++ b/ui/src/components/business/ContractsView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import {
-  FileText, Plus, Trash2, Save, X, DollarSign, Calendar,
+  FileText, FileSignature, Plus, Trash2, Save, X, DollarSign, Calendar,
   FileUp, Sparkles, Check, CheckCheck, Loader2, CheckCircle2,
   FolderKanban, ReceiptText, ArrowRight,
 } from "lucide-react";
@@ -250,16 +250,21 @@ function ContractRow({ contract, isSelected, onSelect }: {
 
   return (
     <button onClick={onSelect}
-      className={`w-full text-left ${LIST_ROW_PADDING} border-b border-border-subtle transition-colors
+      className={`w-full text-left ${LIST_ROW_PADDING} border-b border-border-subtle transition-colors flex items-center gap-3
         ${isSelected ? "bg-bg-selected" : "hover:bg-bg-hover"}`}>
-      <div className="flex items-center justify-between">
-        <div className="text-sm font-medium truncate">{title}</div>
-        <StatusBadge status={status} />
+      <div className="w-9 h-9 rounded-full bg-bg-card flex items-center justify-center text-sm font-semibold text-secondary shrink-0">
+        <FileSignature size={16} />
       </div>
-      <div className="flex items-center gap-2 text-xs text-tertiary mt-0.5">
-        {clientName && <span>{clientName}</span>}
-        {clientName && priceLabel && <span>·</span>}
-        {priceLabel && <span>{priceLabel}</span>}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-sm font-medium truncate">{title}</div>
+          <StatusBadge status={status} />
+        </div>
+        <div className="flex items-center gap-2 text-xs text-tertiary mt-0.5">
+          {clientName && <span>{clientName}</span>}
+          {clientName && priceLabel && <span>·</span>}
+          {priceLabel && <span>{priceLabel}</span>}
+        </div>
       </div>
     </button>
   );

--- a/ui/src/components/business/ProjectsView.tsx
+++ b/ui/src/components/business/ProjectsView.tsx
@@ -228,18 +228,23 @@ export function ProjectsView() {
               const isHighlighted = !isSelected && navFilter.contractId != null && num(p, "contract_id") === navFilter.contractId;
               return (
                 <button key={p.id} onClick={() => selectProject(p)}
-                  className={`w-full text-left ${LIST_ROW_PADDING} border-b transition-colors
+                  className={`w-full text-left ${LIST_ROW_PADDING} border-b transition-colors flex items-center gap-3
                     ${isSelected ? "bg-bg-selected border-border-subtle" : isHighlighted ? "bg-accent/10 border-accent/30" : "border-border-subtle hover:bg-bg-hover"}`}>
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="text-sm font-medium truncate">{str(p, "title")}</span>
-                    <div className="flex items-center gap-2 shrink-0">
-                      <TagBadge tag={str(p, "tag")} />
-                      <StatusBadge status={projectStatus(p)} />
-                    </div>
+                  <div className="w-9 h-9 rounded-full bg-bg-card flex items-center justify-center text-sm font-semibold text-secondary shrink-0">
+                    <FolderKanban size={16} />
                   </div>
-                  {clientName(p) && (
-                    <div className="text-xs text-tertiary mt-0.5 truncate">{clientName(p)}</div>
-                  )}
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-sm font-medium truncate">{str(p, "title")}</span>
+                      <div className="flex items-center gap-2 shrink-0">
+                        <TagBadge tag={str(p, "tag")} />
+                        <StatusBadge status={projectStatus(p)} />
+                      </div>
+                    </div>
+                    {clientName(p) && (
+                      <div className="text-xs text-tertiary mt-0.5 truncate">{clientName(p)}</div>
+                    )}
+                  </div>
                 </button>
               );
             })


### PR DESCRIPTION
## Summary
- Add circular icon avatars to Contracts and Projects list rows, matching the layout used by recurring expenses
- Use `FileSignature` for contracts and `FolderKanban` for projects — the same icons as in the sidebar

## Test plan
- [x] Open Contracts view and confirm each list row shows a circular `FileSignature` icon on the left
- [x] Open Projects view (list mode) and confirm each list row shows a circular `FolderKanban` icon on the left
- [x] Verify row selection, status badges, and subtitles still display correctly
- [x] Confirm icons match the sidebar entries for Contracts and Projects


Made with [Cursor](https://cursor.com)