### PR TITLE
fix: use invoicing role contact for invoice email

### DIFF
--- a/tuttle/app/invoicing/intent.py
+++ b/tuttle/app/invoicing/intent.py
@@ -581,7 +581,7 @@ class InvoicingIntent(Intent):
         try:
             user = self._user_data_source.get_user()
             client = invoice.contract.client
-            contact = client.invoicing_contact if client else None
+            contact = client.invoice_recipient_contact if client else None
             greeting = contact.name if contact and contact.name else client.name
             recipient = contact.email if contact and contact.email else None
             if not recipient:
@@ -643,7 +643,7 @@ Best regards,
             user = self._user_data_source.get_user()
             # open email client with message pre-filled
             client = invoice.contract.client
-            contact = client.invoicing_contact if client else None
+            contact = client.invoice_recipient_contact if client else None
             greeting = contact.name if contact and contact.name else client.name
             recipient = contact.email if contact and contact.email else None
 

--- a/tuttle/invoicing.py
+++ b/tuttle/invoicing.py
@@ -184,7 +184,7 @@ def generate_invoice_email(
     Returns None when no contact email is available.
     """
     client = invoice.client
-    contact = client.invoicing_contact if client else None
+    contact = client.invoice_recipient_contact if client else None
     greeting = contact.first_name if contact and contact.first_name else client.name
     recipient = contact.email if contact and contact.email else None
 

--- a/tuttle/model.py
+++ b/tuttle/model.py
@@ -373,17 +373,33 @@ class Client(RpcMixin, SQLModel, table=True):
     )
 
     @property
+    def invoice_recipient_contact(self) -> Optional[Contact]:
+        """Contact to use for invoice delivery.
+
+        Prefer the legacy direct invoicing contact, but also support the
+        many-to-many contact association used by the current contact UI.
+        """
+        if self.invoicing_contact:
+            return self.invoicing_contact
+        for association in self.client_contacts:
+            if (association.role or "").strip().casefold() == "invoicing":
+                return association.contact
+        return None
+
+    @property
     def invoice_recipient_name(self) -> str:
         """Name to use on invoices: contact name if available, else client name."""
-        if self.invoicing_contact and self.invoicing_contact.name:
-            return self.invoicing_contact.name
+        contact = self.invoice_recipient_contact
+        if contact and contact.name:
+            return contact.name
         return self.name
 
     @property
     def invoice_recipient_address(self) -> Optional["Address"]:
         """Address for invoices: prefer contact address, fall back to client address."""
-        if self.invoicing_contact and self.invoicing_contact.address:
-            return self.invoicing_contact.address
+        contact = self.invoice_recipient_contact
+        if contact and contact.address:
+            return contact.address
         return self.address
 
 

--- a/tuttle_tests/test_invoice.py
+++ b/tuttle_tests/test_invoice.py
@@ -13,6 +13,8 @@ from tuttle.calendar import get_month_start_end
 from tuttle.model import (
     Address,
     Client,
+    ClientContact,
+    Contact,
     Contract,
     ContractCharge,
     Invoice,
@@ -20,6 +22,7 @@ from tuttle.model import (
     InvoiceNote,
     Project,
     TaxCategory,
+    User,
 )
 from tuttle.time import ChargeBasis, ContractType, Cycle, TimeUnit
 
@@ -61,6 +64,31 @@ def test_invoice():
     assert the_invoice.sum == Decimal(1500)
     assert the_invoice.VAT_total == Decimal(300)
     assert the_invoice.total == Decimal(1800)
+
+
+def test_generate_invoice_email_uses_invoicing_role_contact():
+    """Clients with many-to-many invoicing contacts can still send invoices."""
+    contact = Contact(first_name="Jill", last_name="Invoice", email="billing@example.com")
+    client = Client(name="Client Corp")
+    client.client_contacts.append(ClientContact(client=client, contact=contact, role=" invoicing "))
+    contract = Contract(
+        title="Retainer",
+        client=client,
+        rate=Decimal("100"),
+        currency="EUR",
+        unit=TimeUnit.hour,
+        units_per_workday=8,
+        term_of_payment=14,
+        billing_cycle=Cycle.monthly,
+    )
+    invoice = Invoice(number="INV-1", date=datetime.date(2026, 7, 29), contract=contract)
+    user = User(first_name="Harry", last_name="Tuttle")
+
+    email = invoicing.generate_invoice_email(invoice, user)
+
+    assert email is not None
+    assert email["recipient"] == "billing@example.com"
+    assert "Dear Jill" in email["body"]
 
 
 def test_generate_invoice(


### PR DESCRIPTION
## Summary

Fixes #487.

The invoice email path only looked at the legacy `client.invoicing_contact` relationship. The current contacts UI can also attach contacts through the `ClientContact` association with role `invoicing`, which meant a client could visibly have an invoicing contact with an email address while Send Invoice still failed with “No contact email available”.

This adds a shared invoice-recipient contact lookup that:

- keeps preferring the legacy direct invoicing contact
- falls back to a many-to-many `ClientContact` whose role is `invoicing`
- reuses that lookup for invoice/reminder email composition and invoice recipient name/address helpers
- adds regression coverage for generating invoice emails from an invoicing-role contact

AI assistance was used while drafting this change; I reviewed the code path and verified the final patch locally.

## Checklist

- [x] I have read the [Contributing guide](../CONTRIBUTING.md).
- [ ] I have installed and tested the application for my platform (`just dev`).
  - Not run: this is a backend/model email-recipient fix and `just` is not installed in this environment.
- [ ] The test suite passes locally (`just test`).
  - Equivalent run: `pytest -q` → 549 passed, 1 skipped.
- [ ] Pre-commit hooks are installed and pass (`just precommit`).
  - Not run: `just` is not installed in this environment. Ran `ruff check ...` and `git diff --check` instead.
- [x] I have added or updated tests where appropriate.
- [x] I have updated the documentation / docstrings where appropriate.
- [ ] If my change touches the schema (`tuttle/model.py`), I generated and reviewed an Alembic migration (`just migrate "<msg>"`).
  - Not applicable: this only adds Python properties/helper logic; no SQLModel fields, tables, or relationships changed.
- [ ] If my change affects the graphical user interface, I have provided screenshots.
  - Not applicable: no UI files changed.
- [x] I understand and can explain all submitted changes; if AI assistance was significant, I have disclosed it in the summary above.

## Verification

```bash
uv sync --dev
source .venv/bin/activate
python -m py_compile tuttle/model.py tuttle/invoicing.py tuttle/app/invoicing/intent.py tuttle_tests/test_invoice.py
pytest tuttle_tests/test_invoice.py -q
pytest -q
ruff check tuttle/model.py tuttle/invoicing.py tuttle/app/invoicing/intent.py tuttle_tests/test_invoice.py
git diff --check
```

Results:

- `pytest tuttle_tests/test_invoice.py -q`: 41 passed
- `pytest -q`: 549 passed, 1 skipped
- `ruff check ...`: All checks passed
- `git diff --check`: no whitespace errors
