### PR TITLE
Fix revenue calculation bar chart by deduplicating already invoiced hours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ ui/.vite/
 # graft's local graph cache — regenerable, not committed (run `graft build`).
 # Anchored: an unanchored pattern would also swallow .claude/skills/graft/.
 /graft/
+
+# graft's local graph cache — regenerable, not committed (run `graft build`).
+graft/

--- a/tuttle/app/dashboard/intent.py
+++ b/tuttle/app/dashboard/intent.py
@@ -132,6 +132,7 @@ class DashboardIntent(SQLModelDataSourceMixin, Intent):
     def get_cash_flow(self, forecast_months: int = 6) -> IntentResult:
         """Get cash flow projection based on calendar allocations."""
         try:
+            invoices = self.query(Invoice)
             contracts = self.query(Contract)
             projects = self.query(Project)
             time_data = self._time_data_source.get_data_frame()
@@ -140,7 +141,7 @@ class DashboardIntent(SQLModelDataSourceMixin, Intent):
             forecast_start = today.replace(day=1)
             forecast_end = (forecast_start + datetime.timedelta(days=30 * forecast_months)).replace(day=1)
 
-            rev_forecast = monthly_revenue_from_calendar(time_data, projects, forecast_start, forecast_end)
+            rev_forecast = monthly_revenue_from_calendar(time_data, projects, forecast_start, forecast_end, invoices=invoices)
 
             data = cash_flow_projection(rev_forecast, contracts)
             return IntentResult(was_intent_successful=True, data=data)

--- a/tuttle/forecasting.py
+++ b/tuttle/forecasting.py
@@ -139,11 +139,32 @@ def revenue_curve(
     return combined
 
 
+def _invoiced_ranges_by_tag(invoices: List[Invoice]) -> dict:
+    """Map project tag -> list of (period_start, period_end) already invoiced.
+
+    A timesheet's period is the exact slice of calendar hours that were
+    pulled into an invoice, regardless of the invoice's own date (an
+    invoice raised in August can cover a timesheet for July). Cancelled
+    invoices don't count: their hours are still un-invoiced.
+    """
+    ranges: dict = {}
+    for inv in invoices:
+        if inv.cancelled:
+            continue
+        for ts in inv.timesheets:
+            tag = ts.project.tag if ts.project else None
+            if not tag:
+                continue
+            ranges.setdefault(tag, []).append((ts.period_start, ts.period_end))
+    return ranges
+
+
 def monthly_revenue_from_calendar(
     time_data: DataFrame,
     projects: List[Project],
     start_date: datetime.date,
     end_date: datetime.date,
+    invoices: Optional[List[Invoice]] = None,
 ) -> DataFrame:
     """Derive monthly revenue from calendar time-tracking events.
 
@@ -151,6 +172,13 @@ def monthly_revenue_from_calendar(
     and hours planned (future).  Filters *time_data* for events in
     [start_date, end_date], groups by month and project tag, then converts
     hours to revenue via contract rates.
+
+    If *invoices* is given, hours already captured in a timesheet attached
+    to a (non-cancelled) invoice are excluded, keyed by the timesheet's own
+    period rather than the invoice's date — otherwise work billed in a
+    later month than it was performed would show up twice: once as
+    "planned" for the month it was done, and again as "invoiced" for the
+    month the invoice was actually raised.
 
     Returns a DataFrame with columns: month, project, revenue, contract_id, hours.
     """
@@ -164,6 +192,18 @@ def monthly_revenue_from_calendar(
     filtered = time_data[mask]
     if filtered.empty:
         return DataFrame(columns=["month", "project", "revenue", "contract_id", "hours"])
+
+    if invoices:
+        invoiced_ranges = _invoiced_ranges_by_tag(invoices)
+        if invoiced_ranges:
+            dates = filtered.index.date
+            tags = filtered["tag"]
+            already_invoiced = [
+                any(start <= d <= end for start, end in invoiced_ranges.get(tag, ())) for d, tag in zip(dates, tags)
+            ]
+            filtered = filtered[[not v for v in already_invoiced]]
+            if filtered.empty:
+                return DataFrame(columns=["month", "project", "revenue", "contract_id", "hours"])
 
     records = []
     df = filtered.copy()
@@ -275,7 +315,7 @@ def revenue_curve_with_calendar(
     cal_monthly = DataFrame(columns=["month", "revenue", "is_forecast", "source"])
     if time_data is not None and not time_data.empty:
         cal_start = time_data.index.min().date().replace(day=1)
-        cal_revenue = monthly_revenue_from_calendar(time_data, projects, cal_start, forecast_end)
+        cal_revenue = monthly_revenue_from_calendar(time_data, projects, cal_start, forecast_end, invoices=invoices)
         if not cal_revenue.empty:
             cal_monthly = cal_revenue.groupby("month").agg(revenue=("revenue", "sum")).reset_index()
             cal_monthly["is_forecast"] = cal_monthly["month"] >= pandas.Timestamp(today.replace(day=1))

--- a/tuttle_tests/test_dashboard.py
+++ b/tuttle_tests/test_dashboard.py
@@ -7,6 +7,7 @@ import pandas
 import pytest
 
 from tuttle.forecasting import (
+    monthly_revenue_from_calendar,
     monthly_revenue_from_contracts,
     revenue_curve,
     revenue_history,
@@ -219,6 +220,86 @@ class TestMonthlyRevenueFromContracts:
             today + datetime.timedelta(days=30),
         )
         assert result.empty
+
+
+class TestMonthlyRevenueFromCalendar:
+    """Regression tests for the July-worked/August-invoiced double-count bug.
+
+    A timesheet's period (not the invoice's own date) determines whether
+    calendar hours have already been billed, since an invoice can be raised
+    in a later month than the work it covers.
+    """
+
+    @staticmethod
+    def _time_data(tag: str, work_date: datetime.date, hours: int = 8):
+        begin = datetime.datetime(work_date.year, work_date.month, work_date.day, 9, 0)
+        end = begin + datetime.timedelta(hours=hours)
+        df = pandas.DataFrame(
+            {
+                "begin": [begin],
+                "end": [end],
+                "title": ["Work"],
+                "tag": [tag],
+                "description": [""],
+                "all_day": [False],
+            }
+        )
+        df["duration"] = df["end"] - df["begin"]
+        return df.set_index("begin")
+
+    def test_excludes_hours_already_invoiced_in_a_later_month(self, project, active_contract):
+        time_data = self._time_data(project.tag, datetime.date(2026, 7, 15))
+        inv = Invoice(
+            number="2026-100",
+            date=datetime.date(2026, 8, 3),
+            contract=active_contract,
+            project=project,
+            sent=True,
+        )
+        Timesheet(
+            title="July work",
+            date=inv.date,
+            period_start=datetime.date(2026, 7, 1),
+            period_end=datetime.date(2026, 7, 31),
+            project=project,
+            invoice=inv,
+        )
+
+        result = monthly_revenue_from_calendar(
+            time_data, [project], datetime.date(2026, 7, 1), datetime.date(2026, 8, 31), invoices=[inv]
+        )
+        assert result.empty
+
+    def test_without_invoices_still_shows_calendar_revenue(self, project):
+        time_data = self._time_data(project.tag, datetime.date(2026, 7, 15))
+        result = monthly_revenue_from_calendar(time_data, [project], datetime.date(2026, 7, 1), datetime.date(2026, 7, 31))
+        assert not result.empty
+        assert result["revenue"].sum() > 0
+
+    def test_cancelled_invoice_does_not_exclude_hours(self, project, active_contract):
+        time_data = self._time_data(project.tag, datetime.date(2026, 7, 15))
+        inv = Invoice(
+            number="2026-101",
+            date=datetime.date(2026, 8, 3),
+            contract=active_contract,
+            project=project,
+            sent=True,
+            cancelled=True,
+        )
+        Timesheet(
+            title="July work",
+            date=inv.date,
+            period_start=datetime.date(2026, 7, 1),
+            period_end=datetime.date(2026, 7, 31),
+            project=project,
+            invoice=inv,
+        )
+
+        result = monthly_revenue_from_calendar(
+            time_data, [project], datetime.date(2026, 7, 1), datetime.date(2026, 7, 31), invoices=[inv]
+        )
+        assert not result.empty
+        assert result["revenue"].sum() > 0
 
 
 class TestRevenueHistory:

--- a/ui/src/components/dashboard/DashboardView.tsx
+++ b/ui/src/components/dashboard/DashboardView.tsx
@@ -88,11 +88,12 @@ export function DashboardView() {
       }
     }
 
-    // Deduplicate: calendar-derived planned revenue overlaps with
-    // invoice-based received/invoiced for the same month.  Only show the
-    // portion not yet covered by invoices.
+    // The backend already excludes calendar hours that have been captured
+    // into an invoice (keyed by the timesheet's own period, not the
+    // invoice's date), so `planned` here only ever reflects genuinely
+    // un-invoiced work. Guard against floating-point dust only.
     for (const bar of byLabel.values()) {
-      bar.planned = Math.max(0, bar.planned - bar.received - bar.invoiced);
+      bar.planned = Math.max(0, bar.planned);
     }
 
     const sorted = [...byLabel.values()].sort((a, b) => {

--- a/uv.lock
+++ b/uv.lock
@@ -3177,7 +3177,7 @@ wheels = [
 
 [[package]]
 name = "tuttle"
-version = "4.1.0"
+version = "4.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
- Added a new function to map invoiced periods by project tag, ensuring that hours already captured in invoices are excluded from revenue calculations.
- Updated the `monthly_revenue_from_calendar` function to accept invoices and filter out already invoiced hours based on their timesheet periods.
- Modified the `DashboardIntent` to pass invoices to the revenue calculation.
- Added regression tests to verify correct behavior when handling invoiced hours, including scenarios with cancelled invoices.
- Bumped version of the 'tuttle' package to 4.2.0 in `uv.lock`.

