### PR TITLE
fix(site): state Prototype Fund support as past, not ongoing

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@
       </div>
       <div>
         <dt>Open source</dt>
-        <dd>GPLv3, built in the open, funded by the Prototype Fund.</dd>
+        <dd>GPLv3, built in the open, free to use and to fork.</dd>
       </div>
     </dl>
   </div>
@@ -618,8 +618,8 @@
         </p>
       </div>
       <div>
-        <p style="margin: 0 0 10px;">Funded in 2022 by the <a href="https://prototypefund.de" style="color: var(--text-secondary);">Prototype Fund</a>.</p>
-        <div class="funding"><img src="assets/images/pf_funding_logos.svg" alt="Funded by the German Federal Ministry of Education and Research and the Prototype Fund" /></div>
+        <p style="margin: 0 0 10px;">Tuttle received funding from the <a href="https://prototypefund.de" style="color: var(--text-secondary);">Prototype Fund</a> in 2022.</p>
+        <div class="funding"><img src="assets/images/pf_funding_logos.svg" alt="Tuttle received funding from the German Federal Ministry of Education and Research and the Prototype Fund in 2022" /></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

The landing page merged in #505 implied the project is currently funded by the
Prototype Fund. It is not — the funding was in 2022. Two places said so:

- The value strip read "GPLv3, built in the open, funded by the Prototype Fund",
  which reads as present tense. It now says "free to use and to fork", keeping the
  open-source point without the funding claim.
- The footer read "Funded in 2022 by the Prototype Fund", which is ambiguous about
  whether that funding continues. It now reads "Tuttle received funding from the
  Prototype Fund in 2022", and the funding logo's alt text says the same.

The logo itself stays, since acknowledging past support is the point of it.

Text only, no layout or logic change.

## Checklist

- [x] I have read the [Contributing guide](../CONTRIBUTING.md).
- [ ] I have installed and tested the application for my platform (`just dev`).
- [x] The test suite passes locally (`just test`).
- [x] Pre-commit hooks are installed and pass (`just precommit`).
- [x] I have added or updated tests where appropriate.
- [x] I have updated the documentation / docstrings where appropriate.
- [x] If my change touches the schema (`tuttle/model.py`), I generated and reviewed an Alembic migration (`just migrate "<msg>"`).
- [x] If my change affects the graphical user interface, I have provided screenshots.
- [x] UI verification evidence is included for product UI changes, or this PR has no product UI surface.
- [x] I understand and can explain all submitted changes; if AI assistance was significant, I have disclosed it in the summary above.

Made with [Cursor](https://cursor.com)