### PR TITLE
fix(site): stop the hero screenshot being squashed on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
 
   a { color: inherit; }
 
-  img { max-width: 100%; display: block; }
+  img { max-width: 100%; height: auto; display: block; }
 
   .wrap { width: 100%; max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
 
@@ -415,7 +415,7 @@
       </p>
 
       <div class="hero-shot reveal">
-        <img src="assets/images/screenshot-dashboard.png" width="1024" height="705"
+        <img src="assets/images/screenshot-dashboard.png" width="1232" height="848"
              alt="Tuttle dashboard showing revenue, outstanding invoices, effective hourly rate and a monthly revenue chart." />
       </div>
     </div>


### PR DESCRIPTION
## Summary

The dashboard screenshot in the hero was distorted on mobile — squashed to a
0.46 aspect ratio instead of its real 1.45.

Cause: the image carried `width=\"1024\" height=\"705\"` attributes that did not
match the actual 1232×848 file, and the base image rule only constrained
`max-width`. On a narrow viewport the width shrank to the column while the height
attribute stayed at 705px, so the browser stretched the image to fill both. The
other screenshots have no dimension attributes and were unaffected.

Fix:

- `height: auto` on the base `img` rule, so aspect always follows the image
  rather than the attributes. This is the actual fix and covers every image on
  the page.
- Correct the hero image's `width`/`height` attributes to the real 1232×848, so
  the browser reserves the right space before the image loads and there is no
  layout shift.

Verified with Playwright at 390px, 360px, 768px and 1440px: the hero image now
renders at 324×223 (aspect 1.453, matching the file) on a 390px viewport, and
all other images keep their natural aspect. Screenshots of the hero, features
and download sections at all four widths are in the verification artifacts.

## Checklist

- [x] I have read the [Contributing guide](../CONTRIBUTING.md).
- [ ] I have installed and tested the application for my platform (`just dev`).
- [x] The test suite passes locally (`just test`).
- [x] Pre-commit hooks are installed and pass (`just precommit`).
- [x] I have added or updated tests where appropriate.
- [x] I have updated the documentation / docstrings where appropriate.
- [x] If my change touches the schema (`tuttle/model.py`), I generated and reviewed an Alembic migration (`just migrate \"<msg>\"`).
- [x] If my change affects the graphical user interface, I have provided screenshots.
- [x] UI verification evidence is included for product UI changes, or this PR has no product UI surface.
- [x] I understand and can explain all submitted changes; if AI assistance was significant, I have disclosed it in the summary above.

Made with [Cursor](https://cursor.com)