### PR TITLE
fix: recover from failed demo data installation

### DIFF
--- a/tuttle/app/users/intent.py
+++ b/tuttle/app/users/intent.py
@@ -408,13 +408,24 @@ class UsersIntent:
         invoice_language: str = "en",
         invoice_template: str = "invoice-modern",
     ) -> IntentResult:
-        """Ensure the Harry Tuttle demo user exists."""
+        """Ensure the Harry Tuttle demo user exists with a fully populated database.
+
+        If a previous attempt registered the demo user but failed to install
+        data (e.g. a rendering error), the incomplete registration is removed
+        and the installation is retried from scratch.
+        """
         from ...demo import install_demo_data
         from ..timetracking.data_source import TimeTrackingDataFrameSource
 
-        if self._app_db.get_user_by_db_file("harry-tuttle.db"):
-            reg = self._app_db.get_user_by_db_file("harry-tuttle.db")
-            return IntentResult(was_intent_successful=True, data=reg)
+        existing = self._app_db.get_user_by_db_file("harry-tuttle.db")
+        if existing:
+            db_path = self._app_db.get_user_db_path("harry-tuttle.db")
+            if self._demo_db_is_populated(db_path):
+                return IntentResult(was_intent_successful=True, data=existing)
+            logger.warning("Demo registration exists but database is empty — reinstalling")
+            self._app_db.remove_user("harry-tuttle.db")
+            if db_path.exists():
+                db_path.unlink()
 
         reg = self._app_db.add_user(
             name="Harry Tuttle",
@@ -433,15 +444,37 @@ class UsersIntent:
             ds.save_source_config("demo", calendar_name="Demo calendar")
             logger.info(f"Cached {len(df)} demo time-tracking events")
 
-        install_demo_data(
-            n_projects=4,
-            db_path=str(db_path),
-            on_cache_timetracking_dataframe=_cache_demo_timetracking,
-            invoice_language=invoice_language,
-            invoice_template=invoice_template,
-        )
+        try:
+            install_demo_data(
+                n_projects=4,
+                db_path=str(db_path),
+                on_cache_timetracking_dataframe=_cache_demo_timetracking,
+                invoice_language=invoice_language,
+                invoice_template=invoice_template,
+            )
+        except Exception:
+            logger.exception("Demo data installation failed — rolling back registration")
+            self._app_db.remove_user("harry-tuttle.db")
+            if db_path.exists():
+                db_path.unlink()
+            raise
+
         logger.info("Demo user Harry Tuttle created with heating-repair data")
         return IntentResult(was_intent_successful=True, data=reg)
+
+    @staticmethod
+    def _demo_db_is_populated(db_path: Path) -> bool:
+        """Quick sanity check: does the demo database have at least one user row?"""
+        if not db_path.exists():
+            return False
+        try:
+            engine = sql_create_engine(f"sqlite:///{db_path}")
+            with SqlSession(engine) as s:
+                user = s.exec(select(User)).first()
+            engine.dispose()
+            return user is not None
+        except Exception:
+            return False
 
     def ensure_db(self, **_kw) -> IntentResult:
         """Ensure app.db exists and switch to last-active user if any."""

--- a/tuttle_tests/test_rpc_dispatch.py
+++ b/tuttle_tests/test_rpc_dispatch.py
@@ -86,6 +86,106 @@ def assert_ok(result: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
+class TestDemoStartPath:
+    """Regression tests for the 'Try with demo data' onboarding flow.
+
+    Mirrors the exact RPC sequence the Electron shell fires when the user
+    clicks the button: ensure_demo → users.list → users.switch → get_active.
+    Also covers recovery from partial/failed installations.
+    """
+
+    def test_full_demo_onboarding_sequence(self, rpc_env):
+        """Happy path: the full sequence produces a usable demo session."""
+        demo_result = dispatch("users.ensure_demo", {})
+        assert_ok(demo_result)
+        assert demo_result["data"]["db_file"] == "harry-tuttle.db"
+
+        users = assert_ok(dispatch("users.list", {}))["data"]
+        assert any(u["db_file"] == "harry-tuttle.db" for u in users)
+
+        switch = dispatch("users.switch", {"db_file": "harry-tuttle.db"})
+        assert_ok(switch)
+
+        active = assert_ok(dispatch("users.get_active", {}))["data"]
+        assert active is not None, "get_active must return a user after switch"
+        assert active["name"] == "Harry Tuttle"
+        assert active["profile"] is not None
+
+    def test_demo_has_projects_and_invoices(self, rpc_env):
+        """The demo database must contain non-empty data for the dashboard."""
+        dispatch("users.switch", {"db_file": "harry-tuttle.db"})
+
+        projects = assert_ok(dispatch("projects.get_all", {}))["data"]
+        assert len(projects) >= 4, "Demo should have at least 4 projects"
+
+        invoices = assert_ok(dispatch("invoicing.get_all", {}))["data"]
+        assert len(invoices) >= 4, "Demo should have at least 4 invoices"
+
+    def test_recovery_from_empty_database(self, rpc_env):
+        """If the demo DB exists but is empty, ensure_demo reinstalls it."""
+        from tuttle.app.users.intent import UsersIntent
+
+        users_intent = UsersIntent()
+        db_path = users_intent._app_db.get_user_db_path("harry-tuttle.db")
+
+        # Wipe the database contents but keep the file
+        from tuttle.db_schema import ensure_schema
+
+        db_path.unlink(missing_ok=True)
+        ensure_schema(f"sqlite:///{db_path}")
+
+        assert not UsersIntent._demo_db_is_populated(db_path)
+
+        result = dispatch("users.ensure_demo", {})
+        assert_ok(result)
+        assert UsersIntent._demo_db_is_populated(db_path)
+
+        dispatch("users.switch", {"db_file": "harry-tuttle.db"})
+        projects = assert_ok(dispatch("projects.get_all", {}))["data"]
+        assert len(projects) >= 4
+
+    def test_recovery_from_missing_database(self, rpc_env):
+        """If the demo DB file is gone, ensure_demo reinstalls it."""
+        from tuttle.app.users.intent import UsersIntent
+
+        users_intent = UsersIntent()
+        db_path = users_intent._app_db.get_user_db_path("harry-tuttle.db")
+        db_path.unlink(missing_ok=True)
+
+        result = dispatch("users.ensure_demo", {})
+        assert_ok(result)
+        assert db_path.exists()
+        assert UsersIntent._demo_db_is_populated(db_path)
+
+    def test_failed_install_rolls_back_registration(self, rpc_env):
+        """If install_demo_data crashes, the registration must not persist."""
+        from unittest.mock import patch
+
+        from tuttle.app.users.intent import UsersIntent
+
+        users_intent = UsersIntent()
+        db_path = users_intent._app_db.get_user_db_path("harry-tuttle.db")
+
+        # Remove existing demo so ensure_demo attempts a fresh install
+        users_intent._app_db.remove_user("harry-tuttle.db")
+        db_path.unlink(missing_ok=True)
+        reset_all()
+        _intents.clear()
+
+        with patch("tuttle.demo.install_demo_data", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError, match="boom"):
+                dispatch("users.ensure_demo", {})
+
+        reg = users_intent._app_db.get_user_by_db_file("harry-tuttle.db")
+        assert reg is None, "Registration must be rolled back after install failure"
+
+        # Reinstall for other tests
+        _intents.clear()
+        result = dispatch("users.ensure_demo", {})
+        assert_ok(result)
+        dispatch("users.switch", {"db_file": "harry-tuttle.db"})
+
+
 class TestLifecycle:
     """The startup sequence the Electron shell runs on every launch."""
 

--- a/ui/src/components/layout/Shell.tsx
+++ b/ui/src/components/layout/Shell.tsx
@@ -97,13 +97,21 @@ export function Shell() {
   async function handleWelcomeDemo() {
     setBootPhase("demo");
     setBootState("loading");
-    await rpc("users.ensure_demo");
+    const demoResult = await rpc("users.ensure_demo");
+    if (!demoResult.ok) {
+      console.error("[shell] ensure_demo failed:", demoResult.error);
+      setBootState("welcome");
+      return;
+    }
     await refreshUsers();
     setBootPhase("switching");
     const demoSwitch = await rpc("users.switch", { db_file: "harry-tuttle.db" });
-    if (demoSwitch.ok) {
-      await refreshActiveUser();
+    if (!demoSwitch.ok) {
+      console.error("[shell] users.switch failed:", demoSwitch.error);
+      setBootState("welcome");
+      return;
     }
+    await refreshActiveUser();
     setBootState("ready");
   }
 


### PR DESCRIPTION
## Summary

- **Backend**: `ensure_demo` now rolls back the `app.db` registration if `install_demo_data` throws, and detects stale registrations from previous failed attempts (registration exists but database has no user rows) by reinstalling from scratch.
- **Frontend**: `handleWelcomeDemo` checks the result of both `ensure_demo` and `users.switch` RPCs — on failure it returns to the welcome screen instead of showing an empty app with "No user".

## Test plan

- [x] Full test suite passes (559 passed)
- [x] Launch app with no existing data, click "Try with demo data" — verify demo loads correctly
- [ ] Simulate a failed install (e.g. temporarily break rendering) and retry — verify it recovers

Made with [Cursor](https://cursor.com)