### PR TITLE
fix: restore migrations in the frozen build (v4.3.0 cannot open any user database)

### DIFF
--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -46,8 +46,10 @@ jobs:
         version: "latest"
     - name: Set up Python
       run: uv python install 3.13
+    # Only runtime + build deps: dev-group packages must never influence what
+    # PyInstaller bundles (see logging.config regression in v4.3.0).
     - name: Install Python dependencies
-      run: uv sync --all-groups
+      run: uv sync --group build
     - name: Build Python core (PyInstaller)
       run: uv run pyinstaller --clean --noconfirm tuttle-rpc.spec
     - name: Smoke-test core (every domain bundled)

--- a/.github/workflows/pack-electron.yml
+++ b/.github/workflows/pack-electron.yml
@@ -42,8 +42,10 @@ jobs:
         version: "latest"
     - name: Set up Python
       run: uv python install 3.13
+    # Only runtime + build deps: dev-group packages must never influence what
+    # PyInstaller bundles (see logging.config regression in v4.3.0).
     - name: Install Python dependencies
-      run: uv sync --all-groups
+      run: uv sync --group build
     - name: Build Python core (PyInstaller)
       run: uv run pyinstaller --clean --noconfirm tuttle-rpc.spec
     # Verify the frozen binary actually bundles every RPC domain before the

--- a/scripts/smoke_core.py
+++ b/scripts/smoke_core.py
@@ -1,39 +1,55 @@
 """Smoke-test the frozen PyInstaller core binary.
 
-Spawns the actual ``dist/tuttle-rpc`` binary and verifies that every RPC
-domain (a ``tuttle/app/<domain>/intent.py`` on disk) is bundled and importable
-in the frozen build. This catches the class of release regression where a
-dynamically-imported intent module is silently dropped from the binary,
-producing ``No module named 'tuttle.app.<domain>'`` only in the distributed app.
+Spawns the actual ``dist/tuttle-rpc`` binary and runs two independent checks:
 
-How it works: the dispatcher imports ``tuttle.app.<domain>.intent`` on the first
-call to any method of that domain. We send each domain a sentinel method name:
+1. **Domain probes** — every RPC domain (a ``tuttle/app/<domain>/intent.py`` on
+   disk) is bundled and importable. Catches the regression where a
+   dynamically-imported intent module is silently dropped from the binary,
+   producing ``No module named 'tuttle.app.<domain>'`` only in the
+   distributed app.
+
+2. **Lifecycle** — the startup sequence actually works end to end against a
+   throwaway data directory: create a user (runs an Alembic migration on a new
+   database), then re-launch the binary and confirm ``db.ensure`` adopts the
+   existing user. Import-time gaps in code the analyzer cannot trace only
+   surface when the code runs; a probe that never touches a database misses
+   them. In v4.3.0 ``logging.config`` was absent from the bundle, so every
+   migration failed, ``db.ensure`` aborted before selecting a database, and the
+   app started with "No user" against an empty default DB — with the domain
+   probes passing.
+
+How the domain probes work: the dispatcher imports ``tuttle.app.<domain>.intent``
+on the first call to any method of that domain. We send each domain a sentinel
+method name:
 
     - missing from bundle  -> error contains "No module named 'tuttle.app.<domain>'"  (FAIL)
     - bundled & importable -> error contains "No handler for ..."                       (PASS)
 
-No database or valid parameters are required.
-
-All probes are written up front and stdin is then closed (EOF). We never
-interleave a write with a blocking read, because the frozen server iterates
-``for line in sys.stdin`` which does read-ahead buffering — on Windows it does
-not yield a line until the buffer fills or EOF, so a write/read ping-pong
-deadlocks there. Writing everything then reading after EOF is deadlock-free and
-bounded by a hard timeout.
+All requests in a run are written up front and stdin is then closed (EOF). We
+never interleave a write with a blocking read, because the frozen server
+iterates ``for line in sys.stdin`` which does read-ahead buffering — on Windows
+it does not yield a line until the buffer fills or EOF, so a write/read
+ping-pong deadlocks there. Writing everything then reading after EOF is
+deadlock-free and bounded by a hard timeout. Anything needing state from an
+earlier call is therefore a separate run, which also mirrors how a real relaunch
+behaves.
 
 Usage:
     uv run python scripts/smoke_core.py
 """
 
 import json
+import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 APP_DIR = REPO_ROOT / "tuttle" / "app"
 PROBE_METHOD = "__smoke_probe__"
 TIMEOUT_SECONDS = 180
+SMOKE_USER_NAME = "Smoke Test User"
 
 
 def discover_domains() -> list[str]:
@@ -44,6 +60,157 @@ def discover_domains() -> list[str]:
 def core_binary() -> Path:
     exe = "tuttle-rpc.exe" if sys.platform.startswith("win") else "tuttle-rpc"
     return REPO_ROOT / "dist" / "tuttle-rpc" / exe
+
+
+def run_calls(binary: Path, calls: list[tuple[str, dict]], data_dir: Path | None = None) -> dict[int, dict]:
+    """Send every call to a fresh core process, then read replies after EOF.
+
+    Returns responses keyed by their 1-based position in *calls*.
+    """
+    requests = "".join(
+        json.dumps({"jsonrpc": "2.0", "id": i, "method": method, "params": params}) + "\n"
+        for i, (method, params) in enumerate(calls, start=1)
+    )
+
+    env = os.environ.copy()
+    if data_dir is not None:
+        env["TUTTLE_DATA_DIR"] = str(data_dir)
+
+    proc = subprocess.Popen(
+        [str(binary)],
+        cwd=str(binary.parent),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+    try:
+        stdout, _stderr = proc.communicate(input=requests, timeout=TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.communicate()
+        raise TimeoutError(f"core did not respond within {TIMEOUT_SECONDS}s — killed")
+
+    responses: dict[int, dict] = {}
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            resp = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(resp, dict) and "id" in resp:
+            responses[resp["id"]] = resp
+    return responses
+
+
+def check_domains(binary: Path, domains: list[str]) -> list[str]:
+    """Every dispatcher-reachable domain is bundled and importable."""
+    print(f"Probing {len(domains)} domains against {binary.name}: {domains}")
+
+    try:
+        responses = run_calls(binary, [(f"{d}.{PROBE_METHOD}", {}) for d in domains])
+    except TimeoutError as exc:
+        return [f"domain probes: {exc}"]
+
+    failures: list[str] = []
+    for i, domain in enumerate(domains, start=1):
+        resp = responses.get(i)
+        if resp is None:
+            failures.append(f"{domain}: no response from core")
+            continue
+        blob = json.dumps(resp)
+        if "No module named" in blob and f"tuttle.app.{domain}" in blob:
+            failures.append(f"{domain}: NOT bundled in frozen binary -> {blob}")
+        else:
+            print(f"  ok   {domain}")
+
+    if failures:
+        failures.append(
+            "A domain reachable via the dispatcher is missing from the frozen "
+            "build. Check tuttle-rpc.spec (collect_submodules) and that the "
+            "domain directory has an __init__.py."
+        )
+    return failures
+
+
+def _payload(resp: dict | None) -> tuple[dict | None, str | None]:
+    """Split a JSON-RPC reply into (result payload, error message)."""
+    if resp is None:
+        return None, "no response from core"
+    if resp.get("error"):
+        return None, str(resp["error"].get("message") or resp["error"])
+    result = resp.get("result") or {}
+    if not result.get("ok"):
+        return None, str(result.get("error") or "call reported ok=false")
+    return result, None
+
+
+def check_lifecycle(binary: Path) -> list[str]:
+    """The startup sequence works end to end against a throwaway data dir."""
+    print("\nExercising startup lifecycle (db.ensure, user creation, migration)")
+    failures: list[str] = []
+
+    with tempfile.TemporaryDirectory(prefix="tuttle-smoke-") as tmp:
+        data_dir = Path(tmp)
+
+        try:
+            first = run_calls(
+                binary,
+                [
+                    ("db.ensure", {}),
+                    ("users.create", {"params": {"name": SMOKE_USER_NAME}}),
+                    ("users.get_active", {}),
+                ],
+                data_dir=data_dir,
+            )
+        except TimeoutError as exc:
+            return [f"lifecycle: {exc}"]
+
+        for step, method in enumerate(["db.ensure", "users.create", "users.get_active"], start=1):
+            _result, error = _payload(first.get(step))
+            if error:
+                failures.append(f"{method} (first launch): {error}")
+
+        active, error = _payload(first.get(3))
+        if not error:
+            user = (active or {}).get("data")
+            if not user:
+                failures.append("users.get_active (first launch): no active user after users.create")
+            elif user.get("name") != SMOKE_USER_NAME:
+                failures.append(f"users.get_active (first launch): unexpected user {user.get('name')!r}")
+
+        # Relaunch: db.ensure must migrate and adopt the existing user database.
+        try:
+            second = run_calls(
+                binary,
+                [("db.ensure", {}), ("users.get_active", {})],
+                data_dir=data_dir,
+            )
+        except TimeoutError as exc:
+            return failures + [f"lifecycle relaunch: {exc}"]
+
+        _result, error = _payload(second.get(1))
+        if error:
+            failures.append(f"db.ensure (relaunch): {error}")
+
+        active, error = _payload(second.get(2))
+        if error:
+            failures.append(f"users.get_active (relaunch): {error}")
+        else:
+            user = (active or {}).get("data")
+            if not user or user.get("name") != SMOKE_USER_NAME:
+                failures.append(
+                    "users.get_active (relaunch): existing user was not adopted — "
+                    f"got {user!r}. The app would start with 'No user' against an empty database."
+                )
+
+    if not failures:
+        print("  ok   user created, migrated, and adopted on relaunch")
+    return failures
 
 
 def main() -> int:
@@ -61,80 +228,15 @@ def main() -> int:
         print("ERROR: no domains discovered under tuttle/app/", file=sys.stderr)
         return 1
 
-    print(f"Probing {len(domains)} domains against {binary.name}: {domains}")
-
-    # Build all probe requests; id maps back to domain.
-    requests = "".join(
-        json.dumps(
-            {
-                "jsonrpc": "2.0",
-                "id": i,
-                "method": f"{domain}.{PROBE_METHOD}",
-                "params": {},
-            }
-        )
-        + "\n"
-        for i, domain in enumerate(domains, start=1)
-    )
-    id_to_domain = {i: domain for i, domain in enumerate(domains, start=1)}
-
-    proc = subprocess.Popen(
-        [str(binary)],
-        cwd=str(binary.parent),
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-
-    try:
-        stdout, _stderr = proc.communicate(input=requests, timeout=TIMEOUT_SECONDS)
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        proc.communicate()
-        print(
-            f"ERROR: core did not respond within {TIMEOUT_SECONDS}s — killed.",
-            file=sys.stderr,
-        )
-        return 1
-
-    responses: dict[int, dict] = {}
-    for line in stdout.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            resp = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(resp, dict) and "id" in resp:
-            responses[resp["id"]] = resp
-
-    failures: list[str] = []
-    for i, domain in id_to_domain.items():
-        resp = responses.get(i)
-        if resp is None:
-            failures.append(f"{domain}: no response from core")
-            continue
-        blob = json.dumps(resp)
-        if "No module named" in blob and f"tuttle.app.{domain}" in blob:
-            failures.append(f"{domain}: NOT bundled in frozen binary -> {blob}")
-        else:
-            print(f"  ok   {domain}")
+    failures = check_domains(binary, domains) + check_lifecycle(binary)
 
     if failures:
         print("\nSMOKE TEST FAILED:", file=sys.stderr)
         for f in failures:
             print(f"  - {f}", file=sys.stderr)
-        print(
-            "\nA domain reachable via the dispatcher is missing from the frozen "
-            "build. Check tuttle-rpc.spec (collect_submodules) and that the "
-            "domain directory has an __init__.py.",
-            file=sys.stderr,
-        )
         return 1
 
-    print(f"\nSMOKE TEST PASSED: all {len(domains)} domains bundled & importable.")
+    print(f"\nSMOKE TEST PASSED: {len(domains)} domains bundled, startup lifecycle works.")
     return 0
 
 

--- a/tuttle-rpc.spec
+++ b/tuttle-rpc.spec
@@ -74,7 +74,12 @@ hiddenimports = collect_submodules("tuttle.app") + [
     # SQLModel / SQLAlchemy backends
     "sqlmodel",
     "sqlalchemy.dialects.sqlite",
-    # Alembic — env.py is imported by path at runtime; deps must be bundled
+    # Alembic — env.py is imported by path at runtime, so nothing it imports
+    # is visible to the analyzer. logging.config only ever reached the bundle
+    # as a transitive import of the notebook dev dependencies; when those were
+    # dropped, every migration in the frozen build started failing.
+    "logging.config",
+    "logging.handlers",
     "alembic",
     "alembic.config",
     "alembic.command",

--- a/ui/src/components/layout/Shell.tsx
+++ b/ui/src/components/layout/Shell.tsx
@@ -24,7 +24,7 @@ import { NavigationContext, type NavigationFilter } from "../shared/NavigationCo
 import { rpc } from "../../api/rpc";
 import { useThemeProvider, ThemeContext } from "../../hooks/useTheme";
 
-type BootState = "loading" | "welcome" | "ready";
+type BootState = "loading" | "welcome" | "ready" | "failed";
 
 type BootPhase =
   | "init"
@@ -54,6 +54,7 @@ export function Shell() {
   const [allUsers, setAllUsers] = useState<RegisteredUser[]>([]);
   const [regDialogOpen, setRegDialogOpen] = useState(false);
   const [regLoading, setRegLoading] = useState(false);
+  const [bootError, setBootError] = useState<string | null>(null);
 
   const navigate = useCallback((view: string, filter?: NavigationFilter) => {
     setNavFilter(filter || {});
@@ -70,27 +71,51 @@ export function Shell() {
     if (res.ok && res.data) setAllUsers(res.data);
   }
 
-  async function refreshActiveUser() {
+  async function refreshActiveUser(): Promise<RegisteredUser | null> {
     const res = await rpc<RegisteredUser | null>("users.get_active");
-    if (res.ok && res.data) setActiveUser(res.data);
-    else setActiveUser(null);
+    const user = res.ok && res.data ? res.data : null;
+    setActiveUser(user);
+    return user;
+  }
+
+  function failBoot(message: string) {
+    console.error("[shell] boot failed:", message);
+    setBootError(message);
+    setBootState("failed");
   }
 
   useEffect(() => {
     (async () => {
       setBootPhase("registry");
-      await rpc("db.ensure");
+      const ensured = await rpc("db.ensure");
+      if (!ensured.ok) {
+        failBoot(ensured.error ?? "The database could not be prepared.");
+        return;
+      }
       setBootPhase("users");
       const usersRes = await rpc<RegisteredUser[]>("users.list");
-      const users = usersRes.ok && usersRes.data ? usersRes.data : [];
+      if (!usersRes.ok) {
+        failBoot(usersRes.error ?? "The user registry could not be read.");
+        return;
+      }
+      const users = usersRes.data ?? [];
       setAllUsers(users);
 
       if (users.length === 0) {
         setBootState("welcome");
-      } else {
-        await refreshActiveUser();
-        setBootState("ready");
+        return;
       }
+      // Registered users but no active one means the switch to their database
+      // failed. Starting anyway would show an empty app that looks like data loss.
+      const active = await refreshActiveUser();
+      if (!active) {
+        failBoot(
+          "Your user database could not be opened, so Tuttle stopped instead of " +
+            "starting with an empty workspace. Your data is still on disk.",
+        );
+        return;
+      }
+      setBootState("ready");
     })();
   }, []);
 
@@ -179,6 +204,27 @@ export function Shell() {
         <div className="text-center space-y-2">
           <div className="w-8 h-8 border-2 border-accent border-t-transparent rounded-full animate-spin mx-auto" />
           <p className="text-sm">{PHASE[bootPhase]}…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (bootState === "failed") {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center bg-bg-content p-8 text-primary">
+        <div className="max-w-lg space-y-4 text-center">
+          <h1 className="text-lg font-medium">Tuttle could not start</h1>
+          <p className="text-sm text-secondary">{bootError}</p>
+          <p className="text-xs text-secondary">
+            Nothing was deleted — your databases and their backups remain in the Tuttle data
+            folder. Reinstalling the previous version will let you keep working.
+          </p>
+          <button
+            className="rounded-lg bg-accent px-4 py-2 text-sm text-white"
+            onClick={() => window.location.reload()}
+          >
+            Try again
+          </button>
         </div>
       </div>
     );

--- a/uv.lock
+++ b/uv.lock
@@ -2402,7 +2402,7 @@ wheels = [
 
 [[package]]
 name = "tuttle"
-version = "4.2.1"
+version = "4.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

**v4.3.0 is dead on arrival: it cannot open any user database.** The app starts with "No user" and an empty workspace, which looks exactly like data loss. No data is actually lost.

### Root cause

`tuttle/migrations/env.py:15` imports `logging.config`. Alembic loads `env.py` **by path** at runtime, so PyInstaller's analyzer never sees that import — `logging.config` only ever reached the bundle as a transitive import of the notebook dev dependencies removed in #495. CI builds the core with `uv sync --all-groups`, so dev-group packages were silently shaping the shipped binary. Dropping them dropped `logging.config`.

Reproduced against the released binary:

```
db.ensure → SchemaMigrationError: Schema migration failed (transient):
            No module named 'logging.config'
  tuttle/app/users/intent.py:486  ensure_db
  tuttle/db_schema.py:156         ensure_schema → alembic upgrade
  .../tuttle/migrations/env.py:15 from logging.config import fileConfig
```

Every migration fails, so `ensure_db` aborts before `set_active_db`. The active database stays at the module default `~/.tuttle/tuttle.db` (an empty 0-byte file), `users.list` still works because it reads `app.db`, and `users.get_active` returns `null`. Hence a populated user switcher next to "No user", and empty views. Fresh installs are equally broken — `users.create` and `users.ensure_demo` fail identically, leaving only `app.db` behind.

### Fix

- Declare `logging.config` and `logging.handlers` as hidden imports in `tuttle-rpc.spec`.
- Build the core with `uv sync --group build` in both workflows, so dev-only packages can never again decide what the shipped binary contains.

### Why CI missed it, and what now catches it

`scripts/smoke_core.py` passed this release. It only sent sentinel method names and only failed on `No module named 'tuttle.app.<domain>'`, so it proved every domain was importable and nothing more — it never opened a database or ran a migration. The unit suite runs from source, where the stdlib is complete, so a frozen-only gap is invisible to it by construction.

The smoke test now also drives the real startup lifecycle against a throwaway `TUTTLE_DATA_DIR`: create a user (which runs a migration), relaunch the binary, and assert `db.ensure` adopts that user. Verified both directions:

- Against the **shipped v4.3.0 binary**: all 21 domain probes pass, the lifecycle check fails. This is the exact blindness that let the release out.
- Against a **locally rebuilt binary with the fix**: both phases pass, and my real data loads — active user resolves with profile, 5 projects returned.

### UI: stop rendering a fatal error as an empty app

`Shell.tsx` checked neither `db.ensure` nor `users.list`, and treated "registered users but no active user" as a normal start. That is what turned a fatal backend error into something indistinguishable from data loss. Those results are now checked, and a boot-failure screen names the failure and states that the databases and their backups are still on disk.

### AI assistance disclosure

Diagnosis and implementation were done with Cursor. The root cause was confirmed by piping RPC calls into the shipped binary in `/Applications/Tuttle.app`, and the fix by rebuilding the frozen core locally and re-running both checks.

## Checklist

- [x] I have read the [Contributing guide](../CONTRIBUTING.md).
- [ ] I have installed and tested the application for my platform (`just dev`). — **could not run:** `dist-electron/main.js` is ESM and this local Node/Electron combination fails with `The requested module 'electron' does not provide an export named 'shell'`. Pre-existing and unrelated to this change. Verified via the frozen binary and the RPC layer instead.
- [x] The test suite passes locally (`just test`) — 565 passed.
- [x] Pre-commit hooks are installed and pass (`just precommit`).
- [x] I have added or updated tests where appropriate — the lifecycle phase of `smoke_core.py` is the regression guard; it fails against the broken binary.
- [x] I have updated the documentation / docstrings where appropriate.
- [x] If my change touches the schema (`tuttle/model.py`), I generated and reviewed an Alembic migration — no schema change.
- [ ] If my change affects the graphical user interface, I have provided screenshots. — **not provided**, see below.
- [ ] UI verification evidence is included for product UI changes, or this PR has no product UI surface. — **gap:** the new boot-failure screen could not be captured because Electron will not launch locally (same ESM issue as above). It is covered by `tsc --noEmit` and code review only, and its copy and layout still need a human look. Reviewer note: with the spec fixed, boot resolves an active user and this branch does not run; when it does run it replaces a state that today renders as silent data loss.
- [x] I understand and can explain all submitted changes; if AI assistance was significant, I have disclosed it in the summary above.

## Release plan

Intended for an immediate v4.3.1 patch. Merging through the queue first is deliberate: `core-smoke.yml` runs on `merge_group` only, and this needs the new lifecycle check exercised on all four platforms — only macOS arm64 was verified locally. After publishing, run the hardened smoke against the downloaded artifact, and mark the v4.3.0 release as broken so nobody installs it in the meantime.

Made with [Cursor](https://cursor.com)