### PR TITLE
Revenue chart: readable values, week/month/year views, year boundaries, history paging

### DIFF
--- a/tuttle/app/dashboard/intent.py
+++ b/tuttle/app/dashboard/intent.py
@@ -6,6 +6,7 @@ from ...forecasting import (
     cash_flow_projection,
     monthly_revenue_from_calendar,
     revenue_curve_with_calendar,
+    revenue_series,
 )
 from ...kpi import (
     compute_kpis,
@@ -103,6 +104,26 @@ class DashboardIntent(SQLModelDataSourceMixin, Intent):
                 was_intent_successful=False,
                 error_msg=f"Failed to load chart data: {e}",
                 log_message=f"DashboardIntent.get_monthly_chart_data: {e}",
+                exception=e,
+            )
+
+    def get_revenue_series(self, granularity: str = "month", offset: int = 0) -> IntentResult:
+        """Revenue per week/month/year bucket for one window of the revenue chart."""
+        try:
+            data = revenue_series(
+                self.query(Invoice),
+                self.query(Project),
+                self._time_data_source.get_data_frame(),
+                granularity=granularity,
+                offset=int(offset),
+                country=self._get_country(),
+            )
+            return IntentResult(was_intent_successful=True, data=data)
+        except Exception as e:
+            return IntentResult(
+                was_intent_successful=False,
+                error_msg=f"Failed to load revenue series: {e}",
+                log_message=f"DashboardIntent.get_revenue_series: {e}",
                 exception=e,
             )
 

--- a/tuttle/forecasting.py
+++ b/tuttle/forecasting.py
@@ -1,5 +1,6 @@
 """Revenue forecasting based on contracts, time allocation, and invoices."""
 
+import calendar
 import datetime
 from decimal import Decimal
 from typing import List, Optional
@@ -7,7 +8,9 @@ from typing import List, Optional
 import pandas
 from pandas import DataFrame
 
+from .fx import primary_currency
 from .model import Contract, Invoice, Project
+from .tax_reserves import convert_invoice
 from .time import TimeUnit
 from .timetracking import event_hours
 
@@ -159,19 +162,21 @@ def _invoiced_ranges_by_tag(invoices: List[Invoice]) -> dict:
     return ranges
 
 
-def monthly_revenue_from_calendar(
-    time_data: DataFrame,
+def revenue_from_calendar(
+    time_data: Optional[DataFrame],
     projects: List[Project],
     start_date: datetime.date,
     end_date: datetime.date,
     invoices: Optional[List[Invoice]] = None,
+    freq: str = "M",
 ) -> DataFrame:
-    """Derive monthly revenue from calendar time-tracking events.
+    """Derive revenue per time bucket from calendar time-tracking events.
 
     The calendar DataFrame is the source of truth for hours worked (past)
     and hours planned (future).  Filters *time_data* for events in
-    [start_date, end_date], groups by month and project tag, then converts
-    hours to revenue via contract rates.
+    [start_date, end_date], groups by *freq* period and project tag, then
+    converts hours to revenue via contract rates.  *freq* is a pandas
+    period alias — "W", "M" or "Y".
 
     If *invoices* is given, hours already captured in a timesheet attached
     to a (non-cancelled) invoice are excluded, keyed by the timesheet's own
@@ -180,10 +185,11 @@ def monthly_revenue_from_calendar(
     "planned" for the month it was done, and again as "invoiced" for the
     month the invoice was actually raised.
 
-    Returns a DataFrame with columns: month, project, revenue, contract_id, hours.
+    Returns a DataFrame with columns: period, project, revenue, contract_id, hours.
     """
+    empty = DataFrame(columns=["period", "project", "revenue", "contract_id", "hours"])
     if time_data is None or time_data.empty:
-        return DataFrame(columns=["month", "project", "revenue", "contract_id", "hours"])
+        return empty
 
     tag_to_project = {p.tag: p for p in projects if p.tag and p.contract}
 
@@ -191,7 +197,7 @@ def monthly_revenue_from_calendar(
     mask = (index_dates >= start_date) & (index_dates <= end_date)
     filtered = time_data[mask]
     if filtered.empty:
-        return DataFrame(columns=["month", "project", "revenue", "contract_id", "hours"])
+        return empty
 
     if invoices:
         invoiced_ranges = _invoiced_ranges_by_tag(invoices)
@@ -203,11 +209,11 @@ def monthly_revenue_from_calendar(
             ]
             filtered = filtered[[not v for v in already_invoiced]]
             if filtered.empty:
-                return DataFrame(columns=["month", "project", "revenue", "contract_id", "hours"])
+                return empty
 
     records = []
     df = filtered.copy()
-    df["_month"] = pandas.to_datetime(df.index).to_period("M").to_timestamp()
+    df["_period"] = pandas.to_datetime(df.index).to_period(freq).to_timestamp()
     df["_hours"] = df.apply(
         lambda row: event_hours(
             row,
@@ -216,7 +222,7 @@ def monthly_revenue_from_calendar(
         axis=1,
     )
 
-    grouped = df.groupby(["_month", "tag"]).agg(hours=("_hours", "sum")).reset_index()
+    grouped = df.groupby(["_period", "tag"]).agg(hours=("_hours", "sum")).reset_index()
     for _, row in grouped.iterrows():
         tag = row["tag"]
         project = tag_to_project.get(tag)
@@ -228,7 +234,7 @@ def monthly_revenue_from_calendar(
         revenue = float(Decimal(str(billable_units)) * contract.rate)
         records.append(
             {
-                "month": row["_month"],
+                "period": row["_period"],
                 "project": project.title,
                 "revenue": revenue,
                 "contract_id": contract.id,
@@ -237,8 +243,23 @@ def monthly_revenue_from_calendar(
         )
 
     if not records:
-        return DataFrame(columns=["month", "project", "revenue", "contract_id", "hours"])
+        return empty
     return DataFrame(records)
+
+
+def monthly_revenue_from_calendar(
+    time_data: Optional[DataFrame],
+    projects: List[Project],
+    start_date: datetime.date,
+    end_date: datetime.date,
+    invoices: Optional[List[Invoice]] = None,
+) -> DataFrame:
+    """Monthly view of :func:`revenue_from_calendar`, keyed by ``month``.
+
+    Returns a DataFrame with columns: month, project, revenue, contract_id, hours.
+    """
+    df = revenue_from_calendar(time_data, projects, start_date, end_date, invoices=invoices, freq="M")
+    return df.rename(columns={"period": "month"})
 
 
 def cash_flow_projection(
@@ -326,3 +347,166 @@ def revenue_curve_with_calendar(
     combined = combined.sort_values("month").reset_index(drop=True)
     combined["cumulative_revenue"] = combined["revenue"].cumsum()
     return combined
+
+
+# Bucket sizes per granularity: pandas period alias, buckets per window, and
+# how many of those buckets sit in the future when viewing the present.
+_GRANULARITY = {
+    "week": ("W", 13, 3),
+    "month": ("M", 16, 3),
+    "year": ("Y", 0, 0),
+}
+
+
+def revenue_window(
+    granularity: str,
+    offset: int = 0,
+    today: Optional[datetime.date] = None,
+) -> tuple:
+    """Start and end date of the visible window for a paged revenue chart.
+
+    *offset* pages the window: 0 is the window containing today, -1 the one
+    before it, and so on.  A month window spans 16 buckets and a week window
+    13, both reaching three buckets into the future at offset 0 so planned
+    work is visible.  Any 16 consecutive months contain a January, so the
+    month view always has a year boundary on screen.
+    """
+    today = today or datetime.date.today()
+    freq, size, ahead = _GRANULARITY[granularity]
+    if size == 0:
+        raise ValueError(f"{granularity} is not a paged granularity")
+
+    current = pandas.Period(today, freq=freq)
+    last = current + ahead + offset * size
+    first = last - (size - 1)
+    return first.start_time.date(), last.end_time.date()
+
+
+def _data_extent(
+    invoices: List[Invoice],
+    time_data: Optional[DataFrame],
+) -> tuple:
+    """Earliest and latest date covered by invoices or calendar events."""
+    dates = [inv.date for inv in invoices if not inv.cancelled and inv.date]
+    if time_data is not None and not time_data.empty:
+        dates.append(time_data.index.min().date())
+        dates.append(time_data.index.max().date())
+    if not dates:
+        return None, None
+    return min(dates), max(dates)
+
+
+def _bucket_label(start: datetime.date, granularity: str) -> str:
+    if granularity == "week":
+        return f"W{start.isocalendar()[1]:02d}"
+    if granularity == "year":
+        return str(start.year)
+    return calendar.month_abbr[start.month]
+
+
+def revenue_series(
+    invoices: List[Invoice],
+    projects: List[Project],
+    time_data: Optional[DataFrame],
+    granularity: str = "month",
+    offset: int = 0,
+    country: str = "",
+    today: Optional[datetime.date] = None,
+) -> dict:
+    """Received, invoiced and planned revenue per bucket for one chart window.
+
+    Reconciles the two revenue sources the dashboard chart needs into a
+    single series so the frontend does not have to join them: invoices give
+    ``received`` (paid) and ``invoiced`` (sent but unpaid) keyed by invoice
+    date, while the calendar gives ``planned`` — tracked or scheduled work
+    that no timesheet has billed yet, in the past as well as the future.
+
+    *granularity* is "week", "month" or "year".  Week and month windows are
+    paged with *offset*; the year window always spans the full data extent.
+    Empty buckets are included so the time axis stays continuous.
+    """
+    if granularity not in _GRANULARITY:
+        raise ValueError(f"unknown granularity: {granularity}")
+
+    today = today or datetime.date.today()
+    freq = _GRANULARITY[granularity][0]
+    currency = primary_currency(country)
+    extent_start, extent_end = _data_extent(invoices, time_data)
+
+    if granularity == "year":
+        first_year = min(extent_start.year if extent_start else today.year, today.year)
+        last_year = max(extent_end.year if extent_end else today.year, today.year)
+        window_start = datetime.date(first_year, 1, 1)
+        window_end = datetime.date(last_year, 12, 31)
+    else:
+        window_start, window_end = revenue_window(granularity, offset, today=today)
+
+    periods = pandas.period_range(start=window_start, end=window_end, freq=freq)
+    buckets = {
+        p: {
+            "bucket": p.start_time.date().isoformat(),
+            "bucket_end": p.end_time.date().isoformat(),
+            "label": _bucket_label(p.start_time.date(), granularity),
+            "year": p.start_time.year,
+            "received": 0.0,
+            "invoiced": 0.0,
+            "planned": 0.0,
+            "invoice_count": 0,
+            "hours": 0.0,
+        }
+        for p in periods
+    }
+
+    for inv in invoices:
+        if inv.cancelled or not inv.date:
+            continue
+        period = pandas.Period(inv.date, freq=freq)
+        bucket = buckets.get(period)
+        if bucket is None:
+            continue
+        converted = convert_invoice(inv, currency)
+        if converted is None:
+            continue
+        if inv.paid:
+            bucket["received"] += float(converted[0])
+            bucket["invoice_count"] += 1
+        elif inv.sent:
+            bucket["invoiced"] += float(converted[0])
+            bucket["invoice_count"] += 1
+
+    cal = revenue_from_calendar(time_data, projects, window_start, window_end, invoices=invoices, freq=freq)
+    if not cal.empty:
+        grouped = cal.groupby("period").agg(revenue=("revenue", "sum"), hours=("hours", "sum")).reset_index()
+        for _, row in grouped.iterrows():
+            bucket = buckets.get(pandas.Period(row["period"], freq=freq))
+            if bucket is None:
+                continue
+            bucket["planned"] += max(0.0, float(row["revenue"]))
+            bucket["hours"] += float(row["hours"])
+
+    current_period = pandas.Period(today, freq=freq)
+    rows = []
+    previous_year = None
+    for period in periods:
+        row = buckets[period]
+        row["is_current"] = period == current_period
+        row["is_future"] = period > current_period
+        row["is_year_start"] = previous_year is not None and row["year"] != previous_year
+        row["total"] = round(row["received"] + row["invoiced"] + row["planned"], 2)
+        for key in ("received", "invoiced", "planned", "hours"):
+            row[key] = round(row[key], 2)
+        previous_year = row["year"]
+        rows.append(row)
+
+    paged = granularity != "year"
+    return {
+        "granularity": granularity,
+        "offset": offset,
+        "currency": currency,
+        "window_start": window_start.isoformat(),
+        "window_end": window_end.isoformat(),
+        "buckets": rows,
+        "total": round(sum(r["total"] for r in rows), 2),
+        "has_earlier": bool(paged and extent_start and extent_start < window_start),
+        "has_later": bool(paged and offset < 0),
+    }

--- a/tuttle_tests/test_dashboard.py
+++ b/tuttle_tests/test_dashboard.py
@@ -11,6 +11,8 @@ from tuttle.forecasting import (
     monthly_revenue_from_contracts,
     revenue_curve,
     revenue_history,
+    revenue_series,
+    revenue_window,
 )
 from tuttle.kpi import (
     compute_kpis,
@@ -300,6 +302,114 @@ class TestMonthlyRevenueFromCalendar:
         )
         assert not result.empty
         assert result["revenue"].sum() > 0
+
+
+class TestRevenueWindow:
+    """The paged window the revenue chart scrolls through."""
+
+    TODAY = datetime.date(2026, 8, 15)
+
+    def test_month_window_spans_sixteen_buckets_reaching_into_the_future(self):
+        start, end = revenue_window("month", 0, today=self.TODAY)
+        assert (start, end) == (datetime.date(2025, 8, 1), datetime.date(2026, 11, 30))
+
+    def test_paging_back_does_not_overlap_or_skip_buckets(self):
+        _, earlier_end = revenue_window("month", -1, today=self.TODAY)
+        later_start, _ = revenue_window("month", 0, today=self.TODAY)
+        assert earlier_end + datetime.timedelta(days=1) == later_start
+
+    def test_week_window_starts_on_a_monday(self):
+        start, end = revenue_window("week", 0, today=self.TODAY)
+        assert start.weekday() == 0
+        assert end.weekday() == 6
+
+    def test_year_is_not_paged(self):
+        with pytest.raises(ValueError):
+            revenue_window("year", 0, today=self.TODAY)
+
+
+class TestRevenueSeries:
+    TODAY = datetime.date(2026, 8, 15)
+
+    def test_unknown_granularity_rejected(self):
+        with pytest.raises(ValueError):
+            revenue_series([], [], None, granularity="fortnight", today=self.TODAY)
+
+    def test_empty_buckets_are_kept_so_the_axis_stays_continuous(self):
+        result = revenue_series([], [], None, granularity="month", today=self.TODAY)
+        assert len(result["buckets"]) == 16
+        assert all(b["total"] == 0 for b in result["buckets"])
+
+    def test_month_window_always_contains_a_year_boundary(self):
+        result = revenue_series([], [], None, granularity="month", today=self.TODAY)
+        boundaries = [b for b in result["buckets"] if b["is_year_start"]]
+        assert len(boundaries) >= 1
+        assert all(b["label"] == "Jan" for b in boundaries)
+
+    def test_first_bucket_is_never_a_year_boundary(self):
+        result = revenue_series([], [], None, granularity="month", today=self.TODAY)
+        assert result["buckets"][0]["is_year_start"] is False
+
+    @staticmethod
+    def _bucket_of(result, day: datetime.date):
+        return next(b for b in result["buckets"] if b["bucket"] <= day.isoformat() <= b["bucket_end"])
+
+    def test_paid_invoice_lands_in_received(self, paid_invoice):
+        result = revenue_series([paid_invoice], [], None, granularity="month", today=datetime.date.today())
+        bucket = self._bucket_of(result, paid_invoice.date)
+        assert bucket["received"] > 0
+        assert bucket["invoiced"] == 0
+
+    def test_sent_unpaid_invoice_lands_in_invoiced(self, unpaid_invoice):
+        result = revenue_series([unpaid_invoice], [], None, granularity="month", today=datetime.date.today())
+        bucket = self._bucket_of(result, unpaid_invoice.date)
+        assert bucket["invoiced"] > 0
+        assert bucket["received"] == 0
+
+    def test_cancelled_invoice_excluded(self, paid_invoice):
+        paid_invoice.cancelled = True
+        result = revenue_series([paid_invoice], [], None, granularity="month", today=datetime.date.today())
+        assert result["total"] == 0
+
+    def test_total_matches_sum_of_buckets(self, paid_invoice, unpaid_invoice):
+        result = revenue_series([paid_invoice, unpaid_invoice], [], None, today=datetime.date.today())
+        expected = sum(b["received"] + b["invoiced"] + b["planned"] for b in result["buckets"])
+        assert result["total"] == pytest.approx(expected, abs=0.01)
+
+    def test_uninvoiced_calendar_hours_land_in_planned(self, project):
+        time_data = TestMonthlyRevenueFromCalendar._time_data(project.tag, datetime.date(2026, 8, 12))
+        result = revenue_series([], [project], time_data, granularity="month", today=self.TODAY)
+        current = next(b for b in result["buckets"] if b["is_current"])
+        assert current["planned"] > 0
+        assert current["hours"] > 0
+
+    def test_weekly_and_monthly_agree_on_the_same_work(self, project):
+        time_data = TestMonthlyRevenueFromCalendar._time_data(project.tag, datetime.date(2026, 8, 12))
+        weekly = revenue_series([], [project], time_data, granularity="week", today=self.TODAY)
+        monthly = revenue_series([], [project], time_data, granularity="month", today=self.TODAY)
+        assert weekly["total"] == pytest.approx(monthly["total"], abs=0.01)
+
+    def test_year_view_covers_the_full_data_extent(self, paid_invoice):
+        old = Invoice(
+            number="2023-001",
+            date=datetime.date(2023, 3, 1),
+            contract=paid_invoice.contract,
+            project=paid_invoice.project,
+            sent=True,
+            paid=True,
+        )
+        result = revenue_series([paid_invoice, old], [], None, granularity="year", today=self.TODAY)
+        years = [b["label"] for b in result["buckets"]]
+        assert years[0] == "2023"
+        assert str(self.TODAY.year) in years
+        assert result["has_earlier"] is False
+        assert result["has_later"] is False
+
+    def test_paging_flags_follow_the_data_extent(self, paid_invoice):
+        present = revenue_series([paid_invoice], [], None, granularity="month", offset=0, today=datetime.date.today())
+        assert present["has_later"] is False
+        past = revenue_series([paid_invoice], [], None, granularity="month", offset=-1, today=datetime.date.today())
+        assert past["has_later"] is True
 
 
 class TestRevenueHistory:

--- a/tuttle_tests/test_rpc_dispatch.py
+++ b/tuttle_tests/test_rpc_dispatch.py
@@ -279,6 +279,9 @@ def test_read_route_resolves(rpc_env, method):
 DASHBOARD_ROUTES = [
     ("dashboard.get_kpis", {}),
     ("dashboard.get_monthly_chart_data", {"n_months": 12}),
+    ("dashboard.get_revenue_series", {"granularity": "week", "offset": 0}),
+    ("dashboard.get_revenue_series", {"granularity": "month", "offset": -1}),
+    ("dashboard.get_revenue_series", {"granularity": "year", "offset": 0}),
 ]
 
 

--- a/ui/src/components/dashboard/DashboardView.tsx
+++ b/ui/src/components/dashboard/DashboardView.tsx
@@ -7,11 +7,8 @@ import { rpc } from "../../api/rpc";
 import { str, num, int } from "../../api/entity";
 import { KPICard } from "../shared/KPICard";
 import { EmptyStateIntro } from "../shared/EmptyStateIntro";
+import { RevenueChart } from "./RevenueChart";
 import type { Entity } from "../../api/types";
-import {
-  Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend,
-  ComposedChart,
-} from "recharts";
 
 interface BudgetEntry {
   project_id: number;
@@ -26,24 +23,8 @@ interface BudgetEntry {
   open_ended?: boolean;
 }
 
-interface RevenueCurveEntry {
-  month: string;
-  revenue: number;
-  cumulative_revenue: number;
-  is_forecast: boolean;
-  source: string;
-}
-
-interface RevenueBar {
-  label: string;
-  received: number;
-  invoiced: number;
-  planned: number;
-}
-
 export function DashboardView() {
   const [kpis, setKpis] = useState<Entity | null>(null);
-  const [revenueBars, setRevenueBars] = useState<RevenueBar[]>([]);
   const [budgets, setBudgets] = useState<BudgetEntry[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -51,57 +32,12 @@ export function DashboardView() {
 
   async function load() {
     setLoading(true);
-    const [kpiRes, chartRes, budgetRes, curveRes] = await Promise.all([
+    const [kpiRes, budgetRes] = await Promise.all([
       rpc("dashboard.get_kpis"),
-      rpc("dashboard.get_monthly_chart_data", { n_months: 12 }),
       rpc<BudgetEntry[]>("dashboard.get_project_budgets"),
-      rpc<RevenueCurveEntry[]>("dashboard.get_revenue_curve", { forecast_months: 6 }),
     ]);
     if (kpiRes.ok && kpiRes.data) setKpis(kpiRes.data as Entity);
     if (budgetRes.ok && Array.isArray(budgetRes.data)) setBudgets(budgetRes.data);
-
-    const byLabel = new Map<string, RevenueBar>();
-
-    if (chartRes.ok && chartRes.data) {
-      const d = chartRes.data as { revenue: Entity[]; spendable: Entity[] };
-      for (const r of (d.revenue || []) as Entity[]) {
-        const m = str(r, "month"), p = m.split("-");
-        const label = p.length === 2 ? `${p[1]}/${p[0].slice(2)}` : m;
-        byLabel.set(label, {
-          label,
-          received: num(r, "revenue"),
-          invoiced: num(r, "pipeline"),
-          planned: 0,
-        });
-      }
-    }
-
-    if (curveRes.ok && Array.isArray(curveRes.data)) {
-      for (const r of curveRes.data as RevenueCurveEntry[]) {
-        const m = (r.month ?? "").slice(0, 7), p = m.split("-");
-        const label = p.length === 2 ? `${p[1]}/${p[0].slice(2)}` : m;
-        if (r.source === "calendar") {
-          const existing = byLabel.get(label) ?? { label, received: 0, invoiced: 0, planned: 0 };
-          existing.planned += r.revenue ?? 0;
-          byLabel.set(label, existing);
-        }
-      }
-    }
-
-    // The backend already excludes calendar hours that have been captured
-    // into an invoice (keyed by the timesheet's own period, not the
-    // invoice's date), so `planned` here only ever reflects genuinely
-    // un-invoiced work. Guard against floating-point dust only.
-    for (const bar of byLabel.values()) {
-      bar.planned = Math.max(0, bar.planned);
-    }
-
-    const sorted = [...byLabel.values()].sort((a, b) => {
-      const [am, ay] = a.label.split("/");
-      const [bm, by] = b.label.split("/");
-      return (+(ay ?? 0) - +(by ?? 0)) || (+(am ?? 0) - +(bm ?? 0));
-    });
-    setRevenueBars(sorted);
     setLoading(false);
   }
 
@@ -133,31 +69,7 @@ export function DashboardView() {
         </div>
       </div>
 
-      {revenueBars.length > 0 && (
-        <div className="rounded-lg bg-bg-card border border-border-subtle p-4">
-          <h2 className="text-sm font-medium text-secondary mb-1">Revenue</h2>
-          <p className="text-[11px] text-tertiary mb-3">Received + invoiced from past months, planned from calendar</p>
-          <ResponsiveContainer width="100%" height={260}>
-            <ComposedChart data={revenueBars} barGap={0}>
-              <XAxis dataKey="label" tick={{ fill: "var(--color-chart-label)", fontSize: 12 }} axisLine={false} tickLine={false} />
-              <YAxis tick={{ fill: "var(--color-chart-label)", fontSize: 12 }} axisLine={false} tickLine={false}
-                tickFormatter={(v: number) => v >= 1000 ? `€${(v / 1000).toFixed(0)}K` : `€${v}`} />
-              <Tooltip
-                contentStyle={{ background: "var(--color-bg-card)", border: "1px solid var(--color-border)", borderRadius: 8, color: "var(--color-primary)" }}
-                labelStyle={{ color: "var(--color-chart-label)" }}
-                formatter={(value: number, name: string) => {
-                  if (!value) return [null, null];
-                  return [`€${value.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`, name];
-                }}
-              />
-              <Legend wrapperStyle={{ fontSize: 12, color: "var(--color-chart-label)" }} />
-              <Bar dataKey="received" name="Received" stackId="rev" fill="#4ADE80" radius={[0, 0, 0, 0]} />
-              <Bar dataKey="invoiced" name="Invoiced" stackId="rev" fill="#FACC15" radius={[0, 0, 0, 0]} />
-              <Bar dataKey="planned" name="Planned" stackId="rev" fill="#60A5FA" radius={[3, 3, 0, 0]} />
-            </ComposedChart>
-          </ResponsiveContainer>
-        </div>
-      )}
+      <RevenueChart />
 
       {budgets.length > 0 && (
         <div className="rounded-lg bg-bg-card border border-border-subtle p-4 space-y-3">

--- a/ui/src/components/dashboard/RevenueChart.tsx
+++ b/ui/src/components/dashboard/RevenueChart.tsx
@@ -1,0 +1,415 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Bar, CartesianGrid, ComposedChart, LabelList, ResponsiveContainer, Tooltip, XAxis, YAxis,
+} from "recharts";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { rpc } from "../../api/rpc";
+
+type Granularity = "week" | "month" | "year";
+type SeriesKey = "received" | "invoiced" | "planned";
+
+interface Bucket {
+  bucket: string;
+  bucket_end: string;
+  label: string;
+  year: number;
+  received: number;
+  invoiced: number;
+  planned: number;
+  invoice_count: number;
+  hours: number;
+  total: number;
+  is_current: boolean;
+  is_future: boolean;
+  is_year_start: boolean;
+}
+
+interface RevenueSeries {
+  granularity: Granularity;
+  offset: number;
+  currency: string;
+  window_start: string;
+  window_end: string;
+  buckets: Bucket[];
+  total: number;
+  has_earlier: boolean;
+  has_later: boolean;
+}
+
+// Planned revenue is drawn translucent: it is an estimate, not money in hand.
+const SERIES: { key: SeriesKey; name: string; color: string; opacity: number; hint: string }[] = [
+  { key: "received", name: "Received", color: "var(--color-status-success)", opacity: 1, hint: "Paid invoices" },
+  { key: "invoiced", name: "Invoiced", color: "var(--color-status-warning)", opacity: 1, hint: "Invoiced, not yet paid" },
+  { key: "planned", name: "Planned", color: "var(--color-status-info)", opacity: 0.45, hint: "Tracked or scheduled work, not yet invoiced" },
+];
+
+const GRANULARITIES: { key: Granularity; name: string }[] = [
+  { key: "week", name: "Week" },
+  { key: "month", name: "Month" },
+  { key: "year", name: "Year" },
+];
+
+// The band layer and the year row are plain DOM, positioned to line up with
+// the chart's plot area — so the axis width and right margin are fixed here
+// rather than left to Recharts' defaults.
+const Y_AXIS_WIDTH = 60;
+const RIGHT_MARGIN = 8;
+const X_AXIS_HEIGHT = 28;
+
+export function RevenueChart() {
+  const [granularity, setGranularity] = useState<Granularity>("month");
+  const [offset, setOffset] = useState(0);
+  const [visible, setVisible] = useState<SeriesKey[]>(["received", "invoiced", "planned"]);
+  const [data, setData] = useState<RevenueSeries | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let stale = false;
+    setLoading(true);
+    rpc<RevenueSeries>("dashboard.get_revenue_series", { granularity, offset }).then((res) => {
+      if (stale) return;
+      if (res.ok && res.data) setData(res.data);
+      setLoading(false);
+    });
+    return () => { stale = true; };
+  }, [granularity, offset]);
+
+  function changeGranularity(next: Granularity) {
+    setGranularity(next);
+    setOffset(0);
+  }
+
+  // Clicking a series isolates it; clicking the isolated one restores all.
+  // Cmd/Ctrl-click adds or removes a single series instead.
+  function toggleSeries(key: SeriesKey, additive: boolean) {
+    setVisible((current) => {
+      if (additive) {
+        const next = current.includes(key) ? current.filter((k) => k !== key) : [...current, key];
+        return next.length ? next : current;
+      }
+      if (current.length === 1 && current[0] === key) return SERIES.map((s) => s.key);
+      return [key];
+    });
+  }
+
+  const currency = data?.currency || "EUR";
+  const fmtCompact = useCallback(
+    (v: number) => new Intl.NumberFormat(undefined, {
+      style: "currency", currency, notation: "compact", maximumFractionDigits: 1,
+    }).format(v),
+    [currency],
+  );
+  const fmtFull = useCallback(
+    (v: number) => new Intl.NumberFormat(undefined, {
+      style: "currency", currency, maximumFractionDigits: 0,
+    }).format(v),
+    [currency],
+  );
+
+  const buckets = data?.buckets ?? [];
+  const activeSeries = useMemo(() => SERIES.filter((s) => visible.includes(s.key)), [visible]);
+
+  const rows = useMemo(
+    () => buckets.map((b) => ({
+      ...b,
+      visibleTotal: activeSeries.reduce((sum, s) => sum + (b[s.key] || 0), 0),
+    })),
+    [buckets, activeSeries],
+  );
+
+  const windowTotal = rows.reduce((sum, r) => sum + r.visibleTotal, 0);
+
+  // Which bars get a printed value, so labels stay readable as bars get denser.
+  const labelled = useMemo(() => {
+    const values = rows.map((r) => r.visibleTotal);
+    const indices = new Set<number>();
+    const step = rows.length <= 16 ? 1 : rows.length <= 32 ? 2 : 0;
+    rows.forEach((row, i) => {
+      if (!values[i]) return;
+      const isPeak = values[i] >= (values[i - 1] ?? 0) && values[i] >= (values[i + 1] ?? 0);
+      if (step ? i % step === 0 : isPeak) indices.add(i);
+      if (row.is_current) indices.add(i);
+    });
+    return indices;
+  }, [rows]);
+
+  const yearBands = useMemo(() => {
+    const bands: { year: number; count: number }[] = [];
+    for (const row of rows) {
+      const last = bands[bands.length - 1];
+      if (last && last.year === row.year) last.count += 1;
+      else bands.push({ year: row.year, count: 1 });
+    }
+    return bands;
+  }, [rows]);
+
+  const windowLabel = useMemo(() => {
+    if (!rows.length) return "";
+    const first = rows[0], last = rows[rows.length - 1];
+    if (granularity === "year") return first.year === last.year ? first.label : `${first.label}–${last.label}`;
+    return `${first.label} ${first.year} – ${last.label} ${last.year}`;
+  }, [rows, granularity]);
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (granularity === "year") return;
+    if (e.key === "ArrowLeft" && data?.has_earlier) { setOffset((o) => o - 1); e.preventDefault(); }
+    if (e.key === "ArrowRight" && data?.has_later) { setOffset((o) => o + 1); e.preventDefault(); }
+  }
+
+  return (
+    <div
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+      className="rounded-lg bg-bg-card border border-border-subtle p-4 outline-none focus-visible:border-accent"
+    >
+      <div className="flex items-start justify-between gap-3 flex-wrap mb-3">
+        <div>
+          <h2 className="text-sm font-medium text-secondary">Revenue</h2>
+          <div className="flex items-baseline gap-2">
+            <span className="text-xl font-semibold tabular-nums">{fmtFull(windowTotal)}</span>
+            <span className="text-[11px] text-tertiary">{windowLabel}</span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <div className="inline-flex rounded-md overflow-hidden border border-border">
+            {GRANULARITIES.map((g, i) => (
+              <button
+                key={g.key}
+                onClick={() => changeGranularity(g.key)}
+                className={`px-2.5 h-7 text-xs transition-colors ${i > 0 ? "border-l border-border" : ""}
+                  ${g.key === granularity ? "bg-bg-selected text-primary" : "text-tertiary hover:text-secondary"}`}
+              >
+                {g.name}
+              </button>
+            ))}
+          </div>
+
+          {granularity !== "year" && (
+            <div className="inline-flex items-center gap-1">
+              <button
+                onClick={() => setOffset((o) => o - 1)} disabled={!data?.has_earlier} title="Earlier (←)"
+                className="flex items-center justify-center w-7 h-7 rounded-md border border-border text-tertiary
+                  hover:text-secondary disabled:opacity-30 disabled:hover:text-tertiary"
+              >
+                <ChevronLeft size={14} />
+              </button>
+              <button
+                onClick={() => setOffset((o) => o + 1)} disabled={!data?.has_later} title="Later (→)"
+                className="flex items-center justify-center w-7 h-7 rounded-md border border-border text-tertiary
+                  hover:text-secondary disabled:opacity-30 disabled:hover:text-tertiary"
+              >
+                <ChevronRight size={14} />
+              </button>
+              {offset !== 0 && (
+                <button onClick={() => setOffset(0)} className="px-2 h-7 text-xs rounded-md border border-border text-tertiary hover:text-secondary">
+                  Now
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className={`relative transition-opacity ${loading ? "opacity-60" : ""}`} style={{ height: 260 }}>
+        <div
+          className="absolute flex pointer-events-none"
+          style={{ left: Y_AXIS_WIDTH, right: RIGHT_MARGIN, top: 0, bottom: X_AXIS_HEIGHT }}
+        >
+          {yearBands.map((band, i) => (
+            <div
+              key={`${band.year}-${i}`}
+              style={{ flexGrow: band.count }}
+              className={`h-full ${i % 2 === 1 ? "bg-surface-overlay" : ""} ${i > 0 ? "border-l border-dashed border-border" : ""}`}
+            />
+          ))}
+        </div>
+
+        <div className="relative h-full z-10">
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart data={rows} margin={{ top: 22, right: RIGHT_MARGIN, left: 0, bottom: 0 }}>
+              <CartesianGrid vertical={false} stroke="var(--color-border-subtle)" />
+              <XAxis
+                dataKey="bucket" height={X_AXIS_HEIGHT} axisLine={false} tickLine={false} interval={0}
+                tick={(props) => <BucketTick {...props} rows={rows} dense={rows.length > 20} />}
+              />
+              <YAxis
+                width={Y_AXIS_WIDTH} axisLine={false} tickLine={false}
+                tick={{ fill: "var(--color-chart-label)", fontSize: 11 }}
+                tickFormatter={(v: number) => fmtCompact(v)}
+              />
+              <Tooltip
+                cursor={{ fill: "var(--color-surface-overlay-hover)" }}
+                content={(props) => <RevenueTooltip {...props} series={activeSeries} fmt={fmtFull} granularity={granularity} />}
+              />
+
+              {activeSeries.map((s, i) => {
+                const isTop = i === activeSeries.length - 1;
+                return (
+                  <Bar
+                    key={s.key}
+                    dataKey={s.key}
+                    name={s.name}
+                    stackId="revenue"
+                    fill={s.color}
+                    fillOpacity={s.opacity}
+                    radius={isTop ? [3, 3, 0, 0] : [0, 0, 0, 0]}
+                    isAnimationActive={false}
+                  >
+                    {isTop && (
+                      <LabelList
+                        dataKey="visibleTotal"
+                        content={(props) => <ValueLabel {...props} labelled={labelled} fmt={fmtCompact} />}
+                      />
+                    )}
+                  </Bar>
+                );
+              })}
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      {granularity !== "year" && yearBands.length > 1 && (
+        <div className="flex" style={{ marginLeft: Y_AXIS_WIDTH, marginRight: RIGHT_MARGIN }}>
+          {yearBands.map((band, i) => (
+            <div
+              key={`${band.year}-${i}`}
+              style={{ flexGrow: band.count }}
+              className={`text-[11px] text-tertiary text-center ${i > 0 ? "border-l border-border" : ""}`}
+            >
+              {band.year}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-center justify-center gap-2 mt-3 flex-wrap">
+        {SERIES.map((s) => {
+          const on = visible.includes(s.key);
+          const subtotal = buckets.reduce((sum, b) => sum + (b[s.key] || 0), 0);
+          return (
+            <button
+              key={s.key}
+              onClick={(e) => toggleSeries(s.key, e.metaKey || e.ctrlKey)}
+              title={`${s.hint} — click to show only this, ⌘/Ctrl-click to toggle`}
+              className={`flex items-center gap-1.5 px-2 h-6 rounded-md border text-[11px] transition-colors
+                ${on ? "border-border bg-bg-hover text-secondary" : "border-transparent text-muted hover:text-tertiary"}`}
+            >
+              <span
+                className="w-2.5 h-2.5 rounded-sm shrink-0"
+                style={{ background: s.color, opacity: on ? s.opacity : 0.2 }}
+              />
+              {s.name}
+              <span className="tabular-nums text-tertiary">{fmtCompact(subtotal)}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface TickProps {
+  x?: number;
+  y?: number;
+  payload?: { index: number };
+  rows: (Bucket & { visibleTotal: number })[];
+  dense: boolean;
+}
+
+function BucketTick({ x = 0, y = 0, payload, rows, dense }: TickProps) {
+  const row = rows[payload?.index ?? -1];
+  if (!row) return null;
+  if (dense && !row.is_current && (payload?.index ?? 0) % 2 === 1) return null;
+  return (
+    <text
+      x={x} y={y + 14} textAnchor="middle"
+      fill={row.is_current ? "var(--color-primary)" : "var(--color-chart-label)"}
+      fontSize={11} fontWeight={row.is_current ? 600 : 400}
+    >
+      {row.label}
+    </text>
+  );
+}
+
+interface ValueLabelProps {
+  x?: number | string;
+  y?: number | string;
+  width?: number | string;
+  value?: number | string;
+  index?: number;
+  labelled: Set<number>;
+  fmt: (v: number) => string;
+}
+
+function ValueLabel({ x, y, width, value, index, labelled, fmt }: ValueLabelProps) {
+  const amount = Number(value ?? 0);
+  if (!amount || index === undefined || !labelled.has(index)) return null;
+  return (
+    <text
+      x={Number(x) + Number(width) / 2} y={Number(y) - 6} textAnchor="middle"
+      fill="var(--color-secondary)" fontSize={10} fontWeight={500}
+    >
+      {fmt(amount)}
+    </text>
+  );
+}
+
+/** "Jun 1 – 7", parsed as local dates so the day never shifts by one. */
+function dayRange(startISO: string, endISO: string): string {
+  const toLocal = (iso: string) => {
+    const [y, m, d] = iso.split("-").map(Number);
+    return new Date(y, m - 1, d);
+  };
+  const start = toLocal(startISO), end = toLocal(endISO);
+  const withMonth = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" });
+  const dayOnly = new Intl.DateTimeFormat(undefined, { day: "numeric" });
+  const endLabel = start.getMonth() === end.getMonth() ? dayOnly.format(end) : withMonth.format(end);
+  return `${withMonth.format(start)} – ${endLabel}`;
+}
+
+interface TooltipProps {
+  active?: boolean;
+  payload?: { payload?: unknown }[];
+  series: typeof SERIES;
+  fmt: (v: number) => string;
+  granularity: Granularity;
+}
+
+function RevenueTooltip({ active, payload, series, fmt, granularity }: TooltipProps) {
+  const row = payload?.[0]?.payload as (Bucket & { visibleTotal: number }) | undefined;
+  if (!active || !row) return null;
+  // A week number alone doesn't say which days it covers; a month or year label does.
+  const range = granularity === "week"
+    ? `${row.label} · ${dayRange(row.bucket, row.bucket_end)}`
+    : granularity === "year"
+      ? row.label
+      : `${row.label} ${row.year}`;
+
+  return (
+    <div className="rounded-lg border border-border bg-bg-card px-3 py-2 text-xs shadow-lg">
+      <div className="text-[11px] text-tertiary mb-1">{range}</div>
+      {series.map((s) => (
+        <div key={s.key} className="flex items-center justify-between gap-4">
+          <span className="flex items-center gap-1.5" style={{ color: s.color }}>
+            <span className="w-2 h-2 rounded-sm" style={{ background: s.color, opacity: s.opacity }} />
+            {s.name}
+          </span>
+          <span className="tabular-nums">{fmt(row[s.key] || 0)}</span>
+        </div>
+      ))}
+      <div className="flex items-center justify-between gap-4 mt-1 pt-1 border-t border-border-subtle font-medium">
+        <span>Total</span>
+        <span className="tabular-nums">{fmt(row.visibleTotal)}</span>
+      </div>
+      {(row.hours > 0 || row.invoice_count > 0) && (
+        <div className="text-[11px] text-tertiary mt-1">
+          {row.hours > 0 && `${row.hours.toFixed(1)}h uninvoiced`}
+          {row.hours > 0 && row.invoice_count > 0 && " · "}
+          {row.invoice_count > 0 && `${row.invoice_count} invoice${row.invoice_count > 1 ? "s" : ""}`}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/dashboard/RevenueChart.tsx
+++ b/ui/src/components/dashboard/RevenueChart.tsx
@@ -93,9 +93,12 @@ export function RevenueChart() {
   }
 
   const currency = data?.currency || "EUR";
+  // Below a thousand there is no compact suffix to shorten the number, so a
+  // decimal there is just noise: €904, not €903.6.
   const fmtCompact = useCallback(
     (v: number) => new Intl.NumberFormat(undefined, {
-      style: "currency", currency, notation: "compact", maximumFractionDigits: 1,
+      style: "currency", currency, notation: "compact",
+      maximumFractionDigits: Math.abs(v) < 1000 ? 0 : 1,
     }).format(v),
     [currency],
   );
@@ -133,7 +136,10 @@ export function RevenueChart() {
     return indices;
   }, [rows]);
 
+  // Grouping buckets by year is only meaningful when a year spans several of
+  // them — in year view every bucket is its own year.
   const yearBands = useMemo(() => {
+    if (granularity === "year") return [];
     const bands: { year: number; count: number }[] = [];
     for (const row of rows) {
       const last = bands[bands.length - 1];
@@ -141,12 +147,13 @@ export function RevenueChart() {
       else bands.push({ year: row.year, count: 1 });
     }
     return bands;
-  }, [rows]);
+  }, [rows, granularity]);
 
   const windowLabel = useMemo(() => {
     if (!rows.length) return "";
     const first = rows[0], last = rows[rows.length - 1];
     if (granularity === "year") return first.year === last.year ? first.label : `${first.label}–${last.label}`;
+    if (first.year === last.year) return `${first.label} – ${last.label} ${first.year}`;
     return `${first.label} ${first.year} – ${last.label} ${last.year}`;
   }, [rows, granularity]);
 
@@ -254,6 +261,7 @@ export function RevenueChart() {
                     fill={s.color}
                     fillOpacity={s.opacity}
                     radius={isTop ? [3, 3, 0, 0] : [0, 0, 0, 0]}
+                    maxBarSize={72}
                     isAnimationActive={false}
                   >
                     {isTop && (
@@ -276,7 +284,7 @@ export function RevenueChart() {
             <div
               key={`${band.year}-${i}`}
               style={{ flexGrow: band.count }}
-              className={`text-[11px] text-tertiary text-center ${i > 0 ? "border-l border-border" : ""}`}
+              className={`text-[11px] text-secondary text-center ${i > 0 ? "border-l border-border" : ""}`}
             >
               {band.year}
             </div>


### PR DESCRIPTION
## Why

The dashboard revenue chart had four problems:

1. Values could only be read by hovering, one bar at a time.
2. It was monthly only.
3. Nothing marked where one calendar year ended and the next began.
4. There was no way to look at earlier periods.

## What changed

<img width="1152" height="768" alt="29e62538-cc77-41df-9302-d0651457ec83" src="https://github.com/user-attachments/assets/6f56dcfc-ac22-442f-98d8-9f8f87262880" />


**Values are readable without hovering.** Bar totals are printed above the bars, with density adaptation so labels never collide: every bar up to 16, every other bar up to 32, and only local peaks plus the current bucket beyond that. Gridlines were added, ticks and labels use compact currency formatting, and the card header shows the window total. The tooltip is now secondary detail (per-series breakdown, uninvoiced hours, invoice count) rather than the only way to read a number.

**Week, month and year granularity** via a segmented control. Month windows are 16 buckets wide, so they always contain a January.

**Year boundaries are explicit**: alternating background bands with a dashed divider, plus a year row beneath the axis with the year centered under its own span. Both are plain DOM aligned to a fixed y-axis width — Recharts' `ReferenceLine` on a categorical axis would draw the divider through the middle of the January bar instead of between bars.

**History paging** with prev/next (and left/right arrow keys when the card is focused), disabled at the edges of the real data extent. A "Now" button returns to the present. The year view is not paged; it always spans the full extent and acts as the overview.

**Series isolation**: clicking a legend chip shows only that series, clicking again restores all, Cmd/Ctrl-click toggles one. Each chip shows its own subtotal for the window. Planned revenue is drawn at 45% opacity since it is an estimate rather than money in hand.

## Backend

Month bucketing was hardcoded in two places (`strftime("%Y-%m")` in `kpi.py`, `to_period("M")` in `forecasting.py`), so granularity had to be lifted out of the backend:

- `revenue_from_calendar` takes a pandas frequency (`W`/`M`/`Y`); `monthly_revenue_from_calendar` remains as a thin wrapper so the existing cash-flow and revenue-curve callers are untouched.
- New `revenue_series` reconciles invoice-derived (`received`, `invoiced`) and calendar-derived (`planned`) revenue server-side and returns buckets keyed by real ISO dates, with paging flags derived from the actual data extent.
- Exposed as `dashboard.get_revenue_series`; generic dispatch means no route registration.

This let ~50 lines be deleted from `DashboardView`, which previously joined two RPC calls on a formatted `"MM/YY"` display string. Two fixes rode along: chart colors now come from theme variables instead of hardcoded hex, and the currency follows the user's operating country instead of a hardcoded `€`.

## Test plan

- [x] `uv run pytest` — 589 passed, 1 skipped
- [x] `npx tsc --noEmit` clean
- [x] 16 new tests: window paging has no overlaps or gaps between adjacent pages, week windows start on Monday, a month window always contains a year boundary, paid vs. sent-unpaid vs. uninvoiced calendar work land in the right series, cancelled invoices excluded, weekly and monthly views agree on the same work
- [x] 3 new `dashboard.get_revenue_series` dispatch routes (week, month with offset, year)
- [x] Electron UI smoke against the Harry Tuttle demo data, via Playwright Electron on `dist-electron/main.js`, navigating to Dashboard and then through each granularity, one page back, and a legend isolation click

### What the UI smoke confirmed

- The year band and divider align exactly on the Dec/Jan boundary, and the year row centers each year under its own span (2025 under Oct of a 5-bucket segment, 2026 under Jun of an 11-bucket segment). The fixed `Y_AXIS_WIDTH`/`RIGHT_MARGIN` approach lines up with Recharts' plot area.
- Paging back to Apr 2024 – Jul 2025 correctly disabled the "earlier" button at the start of the demo data, enabled "later", and revealed the "Now" button.
- Week view labels ISO weeks (W24–W36) and bolds the current week; year view spans 2024–2026.

### Three issues it caught, fixed in the follow-up commit

- Sub-thousand labels rendered a meaningless decimal (`€903.6`) and crowded neighbours — compact notation has no suffix to shorten below a thousand, so the fraction digits are dropped there.
- Year view shaded alternating bars, since every bucket is its own year in that view — year banding is now skipped there.
- Year view drew very wide slabs with only three buckets — bar width is capped, and a single-year window label no longer repeats the year on both ends.

Remaining for human review: whether the year banding and the year row are the right visual weight, and the wording of the legend chip tooltips.