### PR TITLE
fix: never let a source checkout default to the production data directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,9 +179,13 @@ just dev
 
 ### Dev vs production data
 
-`just dev` stores data in `~/.tuttle-dev/` (via the `TUTTLE_DATA_DIR`
-env var) so that development never touches your production database in
-`~/.tuttle/`. To test with your real data, copy it once:
+`~/.tuttle-dev/` is the default data directory for anything run from
+this source checkout — `just dev`, `uv run python -m tuttle.rpc_server`,
+one-off `uv run python -c "..."` snippets, an unpackaged dev build of
+Electron launched some other way, all of it. This is enforced in
+`tuttle/data_dir.py` itself (only a PyInstaller-*frozen* build defaults
+to the real `~/.tuttle`), so it holds even if `TUTTLE_DATA_DIR` never
+gets set. To test with your real data, copy it once *on purpose*:
 
 ```shell
 just sync-data   # one-way copy ~/.tuttle → ~/.tuttle-dev

--- a/justfile
+++ b/justfile
@@ -87,9 +87,12 @@ br: build run
 
 # ── Calendar helper (dev-mode workaround) ───────────────────────────────────
 
-# Build the TuttleCalendar.app helper and request calendar access
+# Build the TuttleCalendar.app helper and request calendar access.
+# This intentionally targets the real ~/.tuttle (not ~/.tuttle-dev):
+# the helper's macOS calendar permission grant is tied to that fixed
+# path, which is where the packaged app also looks for it.
 calendar-setup:
-    uv run --no-sync python -c "from tuttle.eventkit_bridge import _ensure_helper; _ensure_helper()"
+    TUTTLE_DATA_DIR="$HOME/.tuttle" uv run --no-sync python -c "from tuttle.eventkit_bridge import _ensure_helper; _ensure_helper()"
     open --wait-apps ~/.tuttle/TuttleCalendar.app --args request-access
     @echo "Check System Settings → Privacy → Calendars for 'Tuttle Calendar'"
 

--- a/tuttle/data_dir.py
+++ b/tuttle/data_dir.py
@@ -1,18 +1,31 @@
 """Resolve the root data directory for all Tuttle user data.
 
-Default: ``~/.tuttle``.  Override with the ``TUTTLE_DATA_DIR`` env var
-to isolate dev data from a production install (e.g.
-``TUTTLE_DATA_DIR=~/.tuttle-dev just dev``).
+Production (PyInstaller-frozen build): ``~/.tuttle``.
+Everything else — ``uv run``, tests, an unfrozen dev Electron build, an
+agent poking at the core directly — defaults to ``~/.tuttle-dev`` instead.
+Only a real end user's installed app is frozen, so this means source
+checkouts of this repo can never silently read or write someone's real
+data just because a script forgot to set ``TUTTLE_DATA_DIR``. Set the env
+var explicitly (e.g. after ``just sync-data``) to point dev tooling at a
+copy of the real data on purpose.
 """
 
 import os
+import sys
 from pathlib import Path
 
 _DEFAULT = Path.home() / ".tuttle"
+_DEFAULT_DEV = Path.home() / ".tuttle-dev"
 
 
 def get_data_dir() -> Path:
     """Return the root data directory, creating it if necessary."""
-    d = Path(os.environ.get("TUTTLE_DATA_DIR") or _DEFAULT)
+    env = os.environ.get("TUTTLE_DATA_DIR")
+    if env:
+        d = Path(env)
+    elif getattr(sys, "frozen", False):
+        d = _DEFAULT
+    else:
+        d = _DEFAULT_DEV
     d.mkdir(parents=True, exist_ok=True)
     return d

--- a/tuttle/rpc_server.py
+++ b/tuttle/rpc_server.py
@@ -26,6 +26,7 @@ logger.remove()
 logger.add(sys.stderr, level="DEBUG")
 
 from tuttle.app.system.log_sink import sink as _log_sink  # noqa: E402
+from tuttle.data_dir import get_data_dir  # noqa: E402
 
 logger.add(_log_sink, level="DEBUG")
 
@@ -55,6 +56,7 @@ def main():
 
     _start_parent_watchdog()
     logger.info("Tuttle RPC server starting…")
+    logger.info(f"Data directory: {get_data_dir()} (frozen={getattr(sys, 'frozen', False)})")
 
     for line in sys.stdin:
         line = line.strip()

--- a/tuttle_tests/test_data_dir.py
+++ b/tuttle_tests/test_data_dir.py
@@ -1,21 +1,40 @@
 """Tests for tuttle.data_dir — env-var override and default behaviour."""
 
-from pathlib import Path
+import sys
 
 from tuttle.data_dir import get_data_dir
 
 
-def test_default_is_dot_tuttle(monkeypatch, tmp_path):
-    """Without TUTTLE_DATA_DIR, get_data_dir() returns ~/.tuttle."""
+def test_default_is_dot_tuttle_dev_when_unfrozen(monkeypatch, tmp_path):
+    """Without TUTTLE_DATA_DIR, an unfrozen (dev/test) run gets ~/.tuttle-dev.
+
+    A source checkout must never fall back to a real user's ~/.tuttle just
+    because some script forgot to set TUTTLE_DATA_DIR.
+    """
     monkeypatch.delenv("TUTTLE_DATA_DIR", raising=False)
     fake_home = tmp_path / "home"
     fake_home.mkdir()
-    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
 
-    # Re-import to pick up patched home
+    import tuttle.data_dir as mod
+
+    monkeypatch.setattr(mod, "_DEFAULT_DEV", fake_home / ".tuttle-dev")
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+
+    result = mod.get_data_dir()
+    assert result == fake_home / ".tuttle-dev"
+    assert result.is_dir()
+
+
+def test_default_is_dot_tuttle_when_frozen(monkeypatch, tmp_path):
+    """Without TUTTLE_DATA_DIR, a PyInstaller-frozen (production) build gets ~/.tuttle."""
+    monkeypatch.delenv("TUTTLE_DATA_DIR", raising=False)
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
     import tuttle.data_dir as mod
 
     monkeypatch.setattr(mod, "_DEFAULT", fake_home / ".tuttle")
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
 
     result = mod.get_data_dir()
     assert result == fake_home / ".tuttle"
@@ -47,11 +66,11 @@ def test_empty_env_var_falls_back_to_default(monkeypatch, tmp_path):
     monkeypatch.setenv("TUTTLE_DATA_DIR", "")
     fake_home = tmp_path / "home"
     fake_home.mkdir()
-    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
 
     import tuttle.data_dir as mod
 
-    monkeypatch.setattr(mod, "_DEFAULT", fake_home / ".tuttle")
+    monkeypatch.setattr(mod, "_DEFAULT_DEV", fake_home / ".tuttle-dev")
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
 
     result = mod.get_data_dir()
-    assert result == fake_home / ".tuttle"
+    assert result == fake_home / ".tuttle-dev"


### PR DESCRIPTION
## Summary

A dev run from this repo silently migrated the real `~/.tuttle` database, after which the installed release refused to start with `Schema migration failed (transient): Can't locate revision identified by 'f87515d1d068'`. That revision ships in #511, which is on `main` but not in any released build, so the packaged app's bundled migrations don't contain it.

The root cause is that dev/production isolation was **opt-in**: `get_data_dir()` defaulted to the real `~/.tuttle` unless `TUTTLE_DATA_DIR` was set, and the only thing setting it was the `just dev` recipe. Anything running the core another way — `uv run python -m tuttle.rpc_server`, a one-off `uv run python -c "..."`, an unpackaged Electron build launched outside `just dev` — opened the real database, and `ensure_schema()` upgrades to head on open.

- **`tuttle/data_dir.py`** now derives the default from *how the code is running* rather than from an env var somebody has to remember. Only a PyInstaller-frozen build defaults to `~/.tuttle`; everything unfrozen defaults to `~/.tuttle-dev`. `TUTTLE_DATA_DIR` still takes precedence, so aiming dev tooling at real data (e.g. after `just sync-data`) stays possible but has to be deliberate. This reuses the `sys.frozen` test `tuttle/db_schema.py` already makes for the same distinction.
- **`tuttle/rpc_server.py`** logs the resolved data directory at startup. Nothing ever announced which database was in use, which is what made this invisible until a release build choked on it.
- **`justfile`** — `just calendar-setup` genuinely needs the real `~/.tuttle` (the macOS calendar permission grant is tied to that path, and the recipe already opened the helper from there), so it now sets `TUTTLE_DATA_DIR` explicitly instead of relying on the old ambient default.

Why `sys.frozen` is a trustworthy production signal: `tuttle-rpc.spec` is PyInstaller, and both `.github/workflows/pack-electron.yml` and `.github/workflows/core-smoke.yml` build the core through it, so every shipping artifact is frozen.

### Notes for the reviewer

- **Behavior change:** `just demo-reset` previously reset the demo user inside the real `~/.tuttle`; it now hits `~/.tuttle-dev`. That matches the neighbouring `just reset` and is the intended direction, but it is a change rather than a no-op.
- The `[project.scripts] tuttle-rpc` console script is an unfrozen entry point. Nothing ships through it today, but a future Linux package that installs the script instead of the frozen binary would need `TUTTLE_DATA_DIR=~/.tuttle`.
- Not addressed here: the packaged branch of `ui/electron/python-bridge.ts` still passes an ambient `TUTTLE_DATA_DIR` through to the frozen binary, so launching the installed app from a shell exporting the dev dir points production at dev data. Pre-existing and the opposite direction from this bug; happy to lock it down too.
- This does not repair an already-migrated `~/.tuttle`. That needs a build containing `f87515d1d068`, or the `.bak-*` snapshot `ensure_schema()` takes before every upgrade.

## Test plan

- [x] `uv run pytest` — 571 passed, 1 skipped
- [x] `tuttle_tests/test_data_dir.py` rewritten to pin both defaults: unfrozen resolves to `~/.tuttle-dev`, frozen to `~/.tuttle`, explicit env var overrides both
- [x] Verified at runtime, not just against mocked `sys.frozen`: unfrozen with no env var resolves `~/.tuttle-dev`; `sys.frozen = True` resolves `~/.tuttle`; `TUTTLE_DATA_DIR` overrides both
- [x] `ruff check` and `npx tsc --noEmit` clean; pre-commit hooks pass
- [ ] Someone on a fresh clone confirming `just dev` still lands in `~/.tuttle-dev` and that `just calendar-setup` still gets its permission grant

**No product UI surface changed** — this is core/tooling only, so no Electron screenshots.

## Checklist

- [x] I have read the [Contributing guide](../CONTRIBUTING.md).
- [x] The test suite passes locally (`just test`).
- [x] Pre-commit hooks are installed and pass (`just precommit`).
- [x] I have added or updated tests where appropriate.
- [x] I have updated the documentation / docstrings where appropriate (`CONTRIBUTING.md`, module docstring).
- [x] My change does not touch the schema (`tuttle/model.py`), so no migration is needed.
- [x] UI verification evidence is included for product UI changes, or this PR has no product UI surface.
- [x] I understand and can explain all submitted changes. AI assistance was significant: the diagnosis and patch were produced with Cursor, then reviewed and corrected (an earlier revision of this patch duplicated the `.tuttle-dev` default into `python-bridge.ts`, which was dropped as a second source of truth).

Made with [Cursor](https://cursor.com)