### PR TITLE
docs: forbid AI impersonation in discussions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # Agent Instructions
 
+## GitHub
+
+Creating issues and writing PR descriptions is fine — those are
+authored artifacts, not conversations. NEVER post comments, review
+replies, or discussion messages on GitHub. Those are conversations
+between people; posting them under the user's account is impersonation.
+If a comment or reply is needed, draft it in the chat and let the user
+post it themselves.
+
 ## Schema changes
 
 Schema lives in `tuttle/model.py`. Migrations are Alembic in `tuttle/migrations/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,12 @@ Contributors using AI assistance are expected to:
 -   Test changes locally before opening a pull request
 -   Disclose significant AI assistance in the pull request description
 
+### Discussions are between humans
+
+Issue threads, PR reviews, and GitHub Discussions are conversations between human contributors. Fully AI-generated comments and responses are not acceptable — they amount to impersonation and undermine the trust that open-source collaboration depends on.
+
+If you use AI to help draft a reply, quote the AI-generated parts clearly (e.g. with a blockquote or explicit attribution) so reviewers can distinguish your own reasoning from machine output.
+
 # Pull Request Guidelines
 
 ## PR Template


### PR DESCRIPTION
## Summary

- **AGENTS.md**: agents must never post comments, review replies, or discussion messages on GitHub under the user's account — draft them in the chat instead. Creating issues and PR descriptions remains allowed.
- **CONTRIBUTING.md**: fully AI-generated comments and responses in issue threads, PR reviews, and GitHub Discussions are not acceptable. AI-drafted parts should be clearly quoted so reviewers can distinguish human reasoning from machine output.

## Test plan

Documentation-only change — no code, no tests affected.